### PR TITLE
Use timestamp with microseconds.

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -172,10 +172,11 @@ class Message implements MessageInterface
     public function setTimestamp($timestamp)
     {
         if ($timestamp instanceof \DateTime) {
-            $timestamp = $timestamp->format("U");
+            $timestamp = $timestamp->format("U.u");
         }
 
-        $this->timestamp = floor($timestamp);
+        $this->timestamp = (float) $timestamp;
+        
         return $this;
     }
 

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -40,7 +40,7 @@ class MessageTest extends TestCase
         $this->assertEquals(0, $this->message->getTimestamp());
 
         $this->message->setTimestamp("1.23");
-        $this->assertEquals(1, $this->message->getTimestamp());
+        $this->assertEquals(1.23, $this->message->getTimestamp());
     }
 
     public function testVersion()
@@ -168,10 +168,10 @@ class MessageTest extends TestCase
 
     public function testSetTimestamp()
     {
-        $dt = new \DateTime();
+        $dt = new \DateTime('@1393661544.3012');
         $this->message->setTimestamp($dt);
 
-        $this->assertEquals($dt->format("U"), $this->message->getTimestamp());
+        $this->assertEquals($dt->format("U.u"), $this->message->getTimestamp());
     }
 
     public function testMethodChaining()


### PR DESCRIPTION
The [GELF specification](http://www.graylog2.org/gelf#specs) allows to use microseconds in the timestamp parameter.

As I have a project which can generate tens of messages per second, it is really important to me to have as high granularity as possible.

Thanks in advance!
