### PR TITLE
Silence warnings of stream_socket_client()

### DIFF
--- a/src/Gelf/Transport/StreamSocketClient.php
+++ b/src/Gelf/Transport/StreamSocketClient.php
@@ -14,8 +14,8 @@ namespace Gelf\Transport;
 use RuntimeException;
 
 /**
- * StreamSocketClient is a very simple OO-Wrapper around the PHP 
- * stream_socket-library and some specific stream-functions like 
+ * StreamSocketClient is a very simple OO-Wrapper around the PHP
+ * stream_socket-library and some specific stream-functions like
  * fwrite, etc.
  *
  * @author Benjamin Zikarsky <benjamin@zikarsky.de>
@@ -78,10 +78,10 @@ class StreamSocketClient
     protected static function initSocket($scheme, $host, $port)
     {
         $socketDescriptor = sprintf("%s://%s:%d", $scheme, $host, $port);
-        $socket = stream_socket_client(
-            $socketDescriptor, 
-            $errNo, 
-            $errStr, 
+        $socket = @stream_socket_client(
+            $socketDescriptor,
+            $errNo,
+            $errStr,
             static::SOCKET_TIMEOUT
         );
 
@@ -112,8 +112,8 @@ class StreamSocketClient
         // lazy initializing of socket-descriptor
         if (!$this->socket) {
             $this->socket = self::initSocket(
-                $this->scheme, 
-                $this->host, 
+                $this->scheme,
+                $this->host,
                 $this->port
             );
         }


### PR DESCRIPTION
I encountered a problem, when trying to publish a message to an unreachable server.

The StreamSocketClient throws an error, which is right. But PHP also generates a warning on background, which may get printed to the output.

As a solution, I'm using a silence operator before the stream_socket_client().
