### PR TITLE
SSL support for HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ Reinstall dependencies: `composer install`
 
 For usage examples, go to [/examples](https://github.com/bzikarsky/gelf-php/tree/master/examples).
 
+HHVM
+----
+
+While HHVM is supported/tested, there are some restrictions to look out for:
+- Stream-context support is very limited - especially regarding SSL, some things might work as expected (or at all...)
+- `fwrite` does behave a little different
+
+The failing unit-tests are skipped by default when running on HHVM. They are also all annotated with `@group hhvm-failures`.
+You can force to run those failures by setting `FORCE_HHVM_TESTS=1` in the environment. Therefore you can specifically check
+the state of HHVM failures by running:
+
+    `FORCE_HHVM_TESTS=1 hhvm vendor/bin/phpunit --group hhvm-failures`
+
+
 License
 -------
 

--- a/src/Gelf/Transport/SslOptions.php
+++ b/src/Gelf/Transport/SslOptions.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the php-gelf package.
+ *
+ * (c) Benjamin Zikarsky <http://benjamin-zikarsky.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gelf\Transport;
+
+/**
+ * Abstraction of supported SSL configuration paramaters
+ *
+ * @author Benjamin Zikarsky <benjamin@zikarsky.de>
+ */
+class SslOptions
+{
+    /**
+     * Enable certificate validation of remote party
+     *
+     * @param boolean
+     */
+    protected $verifyPeer = true;
+
+    /**
+     * Allow self-signed certificates
+     *
+     * @param boolean
+     */
+    protected $allowSelfSigned = false;
+
+    /**
+     * Path to custom CA
+     *
+     * @param string
+     */
+    protected $caFile = null;
+
+    /**
+     * List of ciphers the SSL layer may use
+     *
+     * Formatted as specified in `ciphers(1)`
+     *
+     * @param string
+     */
+    protected $ciphers = null;
+
+    /**
+     * Whether self-signed certificates are allowed
+     *
+     * @return boolean
+     */
+    public function getAllowSelfSigned()
+    {
+        return $this->allowSelfSigned;
+    }
+
+    /**
+     * Enables or disables the error on self-signed certificates
+     *
+     * @param boolean $allowSelfSigned
+     */
+    public function setAllowSelfSigned($allowSelfSigned)
+    {
+        $this->allowSelfSigned = $allowSelfSigned;
+    }
+
+    /**
+     * Returns the path to a custom CA
+     *
+     * @return string|null
+     */
+    public function getCaFile()
+    {
+        return $this->caFile;
+    }
+
+    /**
+     * Sets the path toa custom CA
+     *
+     * @param string|null $caFile
+     */
+    public function setCaFile($caFile)
+    {
+        $this->caFile = $caFile;
+    }
+
+    /**
+     * Returns des description of allowed ciphers
+     *
+     * @return string|null
+     */
+    public function getCiphers()
+    {
+        return $this->ciphers;
+    }
+
+    /**
+     * Set the allowed SSL/TLS ciphers
+     *
+     * Format must follow `ciphers(1)`
+     *
+     * @param string|null $ciphers
+     */
+    public function setCiphers($ciphers)
+    {
+        $this->ciphers = $ciphers;
+    }
+
+    /**
+     * Whether to check the peer certificate
+     *
+     * @return boolean
+     */
+    public function getVerifyPeer()
+    {
+        return $this->verifyPeer;
+    }
+
+    /**
+     * Enable or disable the peer certificate check
+     *
+     * @param boolean $verifyPeer
+     */
+    public function setVerifyPeer($verifyPeer)
+    {
+        $this->verifyPeer = $verifyPeer;
+    }
+
+    /**
+     * Returns a stream-context representation of this config
+     *
+     * @return array
+     */
+    public function toStreamContext()
+    {
+        $sslContext = array(
+            'verify_peer'       => (bool) $this->verifyPeer,
+            'allow_self_signed' => (bool) $this->allowSelfSigned
+        );
+
+        if (null !== $this->caFile) {
+            $sslContext['cafile'] = $this->caFile;
+        }
+
+        if (null !== $this->ciphers) {
+            $sslContext['ciphers'] = $this->ciphers;
+        }
+
+        return array('ssl' => $sslContext);
+    }
+}

--- a/src/Gelf/Transport/StreamSocketClient.php
+++ b/src/Gelf/Transport/StreamSocketClient.php
@@ -40,6 +40,11 @@ class StreamSocketClient
     protected $scheme;
 
     /**
+     * @var array
+     */
+    protected $context;
+
+    /**
      * @var resource
      */
     protected $socket;
@@ -48,12 +53,14 @@ class StreamSocketClient
      * @param string  $scheme
      * @param string  $host
      * @param integer $port
+     * @param array   $context
      */
-    public function __construct($scheme, $host, $port)
+    public function __construct($scheme, $host, $port, array $context = array())
     {
         $this->scheme = $scheme;
         $this->host = $host;
         $this->port = $port;
+        $this->context = $context;
     }
 
     /**
@@ -67,22 +74,25 @@ class StreamSocketClient
     /**
      * Initializes socket-client
      *
-     * @param string  $scheme like "udp" or "tcp"
+     * @param string  $scheme  like "udp" or "tcp"
      * @param string  $host
      * @param integer $port
+     * @param array   $context
      *
      * @return resource
      *
      * @throws RuntimeException on connection-failure
      */
-    protected static function initSocket($scheme, $host, $port)
+    protected static function initSocket($scheme, $host, $port, array $context)
     {
         $socketDescriptor = sprintf("%s://%s:%d", $scheme, $host, $port);
         $socket = @stream_socket_client(
             $socketDescriptor,
             $errNo,
             $errStr,
-            static::SOCKET_TIMEOUT
+            static::SOCKET_TIMEOUT,
+            \STREAM_CLIENT_CONNECT,
+            stream_context_create($context)
         );
 
         if ($socket === false) {
@@ -116,7 +126,8 @@ class StreamSocketClient
             $this->socket = self::initSocket(
                 $this->scheme,
                 $this->host,
-                $this->port
+                $this->port,
+                $this->context
             );
         }
 
@@ -158,7 +169,7 @@ class StreamSocketClient
     }
 
     /**
-     * Closes underlying socket explicitly 
+     * Closes underlying socket explicitly
      */
     public function close()
     {

--- a/tests/Gelf/Test/LoggerTest.php
+++ b/tests/Gelf/Test/LoggerTest.php
@@ -128,9 +128,9 @@ class LoggerTest extends TestCase
     {
         $test = $this;
         $this->validatePublish(
-             function (MessageInterface $message) use ($test) {
-                 $test->assertEquals("0", $message->getShortMessage());
-             }
+            function (MessageInterface $message) use ($test) {
+                $test->assertEquals("0", $message->getShortMessage());
+            }
         );
 
         $this->logger->info('0');
@@ -141,9 +141,9 @@ class LoggerTest extends TestCase
     {
         $test = $this;
         $this->validatePublish(
-             function (MessageInterface $message) use ($test) {
-                 $test->assertEquals(0, $message->getShortMessage());
-             }
+            function (MessageInterface $message) use ($test) {
+                $test->assertEquals(0, $message->getShortMessage());
+            }
         );
 
         $this->logger->alert(0);

--- a/tests/Gelf/Test/MessageValidatorTest.php
+++ b/tests/Gelf/Test/MessageValidatorTest.php
@@ -117,8 +117,7 @@ class MessageValidatorTest extends TestCase
         $host = "example.local",
         $version = "1.0",
         $additionals = array()
-    )
-    {
+    ) {
         $msg = $this->getMock('Gelf\MessageInterface');
         $msg->expects($this->any())->method('getHost')
             ->will($this->returnValue($host));

--- a/tests/Gelf/Test/Transport/HttpTransportTest.php
+++ b/tests/Gelf/Test/Transport/HttpTransportTest.php
@@ -77,6 +77,22 @@ class HttpTransportTest extends TestCase
         return $transport;
     }
 
+    public function testSslOptionsAreUsed()
+    {
+        $sslOptions = $this->getMock('\\Gelf\\Transport\\SslOptions');
+        $sslOptions->expects($this->exactly(2))->method('toStreamContext')->will($this->returnValue(array()));
+        $sslOptions->expects($this->exactly(2))->method('getVerifyPeer')->will($this->returnValue(true));
+
+        $transport = new HttpTransport("localhost", "12345", "/gelf", $sslOptions);
+
+        $reflectedTransport = new \ReflectionObject($transport);
+        $reflectedGetContext = $reflectedTransport->getMethod('getContext');
+        $reflectedGetContext->setAccessible(true);
+        $context = $reflectedGetContext->invoke($transport);
+
+        $this->assertEquals("localhost", $context['ssl']['CN_match']);
+    }
+
     public function testSetEncoder()
     {
         $encoder = $this->getMock('\\Gelf\\Encoder\\EncoderInterface');

--- a/tests/Gelf/Test/Transport/SslOptionsTest.php
+++ b/tests/Gelf/Test/Transport/SslOptionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the php-gelf package.
+ *
+ * (c) Benjamin Zikarsky <http://benjamin-zikarsky.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gelf\Test\Transport;
+
+use Gelf\TestCase;
+use Gelf\Transport\SslOptions;
+
+class SslOptionsTest extends TestCase
+{
+    public function testState()
+    {
+        $options = new SslOptions();
+
+        // test sane defaults
+        $this->assertTrue($options->getVerifyPeer());
+        $this->assertFalse($options->getAllowSelfSigned());
+        $this->assertNull($options->getCaFile());
+        $this->assertNull($options->getCiphers());
+
+        // test setters
+        $options->setVerifyPeer(false);
+        $options->setAllowSelfSigned(true);
+        $options->setCaFile('/path/to/ca');
+        $options->setCiphers('ALL:!ADH:@STRENGTH');
+
+        $this->assertFalse($options->getVerifyPeer());
+        $this->assertTrue($options->getAllowSelfSigned());
+        $this->assertEquals('/path/to/ca', $options->getCaFile());
+        $this->assertEquals('ALL:!ADH:@STRENGTH', $options->getCiphers());
+    }
+
+    public function testToStreamContext()
+    {
+        $options = new SslOptions();
+
+        $this->assertEquals(array(
+            'ssl' => array(
+                'verify_peer' => true,
+                'allow_self_signed' => false,
+            )
+        ), $options->toStreamContext());
+
+        $options->setVerifyPeer(false);
+        $options->setAllowSelfSigned(true);
+        $options->setCaFile('/path/to/ca');
+        $options->setCiphers('ALL:!ADH:@STRENGTH');
+
+        $this->assertEquals(array(
+            'ssl' => array(
+                'verify_peer' => false,
+                'allow_self_signed' => true,
+                'cafile' => '/path/to/ca',
+                'ciphers' => 'ALL:!ADH:@STRENGTH'
+            )
+        ), $options->toStreamContext());
+
+        $options->setCaFile(null);
+        $options->setCiphers(null);
+
+        $this->assertEquals(array(
+            'ssl' => array(
+                'verify_peer' => false,
+                'allow_self_signed' => true,
+            )
+        ), $options->toStreamContext());
+    }
+}

--- a/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\StreamSocketClient;
-use PHPUnit_Framework_TestCase as TestCase;
+use Gelf\TestCase;
 
 class StreamSocketClientUdpTest extends TestCase
 {

--- a/tests/Gelf/TestCase.php
+++ b/tests/Gelf/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gelf;
+
+abstract class TestCase extends \PHPUnit_Framework_TestCase
+{
+
+    public function failsOnHHVM()
+    {
+        if (defined('HHVM_VERSION') && !getenv('FORCE_HHVM_TESTS')) {
+            $this->markTestSkipped("Relies on missing HHVM functionaility");
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,3 +8,5 @@ if (!file_exists($autoloadFile)) {
 }
 
 require_once $autoloadFile;
+
+require_once __DIR__ . '/Gelf/TestCase.php';


### PR DESCRIPTION
### Issue

The current HTTP transport implementation (see #6, #19) lacks support for SSL/TLS. Some real basic ideas can be taken from the old #6-implementation branch in https://github.com/bzikarsky/gelf-php/blob/issues/6-http-transport/src/Gelf/Transport/HttpTransport.php

Since this is rather big issue, I converted the issue to an internal PR with a custom branch. Please contribute by opening PRs on this branch instead of master.

/cc @steffkes 

--

### Tasks

- [x] Extend `StreamSocketClient` with support for stream-context
- [x] Tests for stream-context-support in `StreamSocketClient` 
- [x] Abstraction for SSL-options (`class Gelf\Transport\SslOptions`) + tests; [possibly relevant options] (http://php.net/manual/context.ssl.php) are:
    - `verify_peer` - default to `true`
    - `allow_self_signed` - default to `false`
    - `cafile` - lots of people with a custom CA...we also need this for testing
    - `ciphers` - Allows us to disable certain ciphers, such  as SSLv3 (...Poodle-Attack)
- [x] Extend HttpTransport with a SslOptions parameter, when NULL (default) is passed, no SSL is used
- [x] Enable SNI (`SNI_enabled` and `SNI_server_name`) when available (OpenSSL 0.9.8j+)
- [x] Enable `CN_match` on Hostname
- [x] Extend HttpTransportTests with checks for a correct scheme and context generation depending on $sslOptions


