### PR TITLE
Pass arrays

### DIFF
--- a/src/Gelf/Logger.php
+++ b/src/Gelf/Logger.php
@@ -181,7 +181,7 @@ class Logger extends AbstractLogger implements LoggerInterface
         // build a replacement array with braces around the context keys
         $replace = array();
         foreach ($context as $key => $val) {
-            $replace['{' . $key . '}'] = $val;
+            $replace['{' . $key . '}'] = is_string($val) ? $val : 'Array';
         }
 
         // interpolate replacement values into the message and return

--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -300,8 +300,12 @@ class Message implements MessageInterface
         return array_filter($message, array($this, 'filter'));
     }
 
+    /**
+     * @param mixed $var
+     * @return bool
+     */
     protected function filter($var)
     {
-        return !is_string($var) || strlen($var);
+        return ($var !== null) && (!is_string($var) || strlen($var));
     }
 }

--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -297,6 +297,11 @@ class Message implements MessageInterface
         }
 
         // return after filtering false, null and empty strings
-        return array_filter($message, 'strlen');
+        return array_filter($message, array($this, 'filter'));
+    }
+
+    protected function filter($var)
+    {
+        return !is_string($var) || strlen($var);
     }
 }


### PR DESCRIPTION
This fix allows to pass array values in the context. The original version fails on this code:
```php
// Now we can log...
$logger->alert("Foobaz!", array('test' => array('x' => '1', 'y' => '2')));
```
With the following message:
```
PHP Notice:  Array to string conversion in gelf-php-wicked/src/Gelf/Logger.php on line 188
PHP Warning:  strlen() expects parameter 1 to be string, array given in gelf-php-wicked/src/Gelf/Message.php on line 300
```
And the arrays are not send anywhere.

With this fix they don't raise errors and are sent correctly and are perfectly supported by the ELK stack.
![kibana](https://cloud.githubusercontent.com/assets/499778/7335418/c6c412ce-ebd5-11e4-81b9-d78c2bd4264b.png)

If you aware this is an excerpt from the [PSR-3 documentation](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#13-context):
```
Every method accepts an array as context data. This is meant to hold any extraneous
information that does not fit well in a string. The array can contain anything.
Implementors MUST ensure they treat context data with as much lenience as
possible. A given value in the context MUST NOT throw an exception nor raise
any php error, warning or notice.
```
The only thing I haven't done is an interpolation for such nested arrays.