### PR TITLE
Define var before passing it as argument

### DIFF
--- a/src/Gelf/Publisher.php
+++ b/src/Gelf/Publisher.php
@@ -66,6 +66,7 @@ class Publisher implements PublisherInterface
             );
         }
 
+        $reason = '';
         if (!$this->messageValidator->validate($message, $reason)) {
             throw new RuntimeException("Message is invalid: $reason");
         }


### PR DESCRIPTION
Static code analysis tools don't like passing in variables
that have not been defined yet.

Personally I think using output arguments at all is bad style,
though I did not touch this due to it being part of a public interface.