### PR TITLE
[BUGFIX] Small typo fix

### DIFF
--- a/src/Gelf/Transport/StreamSocketClient.php
+++ b/src/Gelf/Transport/StreamSocketClient.php
@@ -98,7 +98,7 @@ class StreamSocketClient
         if ($socket === false) {
             throw new RuntimeException(
                 sprintf(
-                    "Failed to create socket-client for %si: %s (%s)",
+                    "Failed to create socket-client for %s: %s (%s)",
                     $socketDescriptor,
                     $errStr,
                     $errNo


### PR DESCRIPTION
This removes an extraneous ``i`` in an error message.