### PR TITLE
Implement IgnoreErrorTransportWrapper

### DIFF
--- a/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
+++ b/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Gelf\Transport;
+
+use Gelf\MessageInterface as Message;
+
+/**
+ * A wrapper for any AbstractTransport to ignore any kind of errors
+ * @package Gelf\Transport
+ */
+class IgnoreErrorTransportWrapper extends AbstractTransport
+{
+
+    /**
+     * @var AbstractTransport
+     */
+    private $transport;
+
+    /**
+     * IgnoreErrorTransportWrapper constructor.
+     *
+     * @param AbstractTransport $transport
+     */
+    public function __construct(AbstractTransport $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    /**
+     * Sends a Message over this transport.
+     *
+     * @param Message $message
+     *
+     * @return int the number of bytes sent
+     */
+    public function send(Message $message)
+    {
+        try {
+            return $this->transport->send($message);
+        } catch (\Exception $e) {
+            return 0;
+        }
+    }
+}

--- a/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
+++ b/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
@@ -50,7 +50,7 @@ class IgnoreErrorTransportWrapper extends AbstractTransport
 
     /**
      * Returns the last error
-     * @return \Exception
+     * @return \Exception|null
      */
     public function getLastError()
     {

--- a/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
+++ b/src/Gelf/Transport/IgnoreErrorTransportWrapper.php
@@ -17,6 +17,11 @@ class IgnoreErrorTransportWrapper extends AbstractTransport
     private $transport;
 
     /**
+     * @var \Exception|null
+     */
+    private $lastError = null;
+
+    /**
      * IgnoreErrorTransportWrapper constructor.
      *
      * @param AbstractTransport $transport
@@ -38,7 +43,17 @@ class IgnoreErrorTransportWrapper extends AbstractTransport
         try {
             return $this->transport->send($message);
         } catch (\Exception $e) {
+            $this->lastError = $e;
             return 0;
         }
+    }
+
+    /**
+     * Returns the last error
+     * @return \Exception
+     */
+    public function getLastError()
+    {
+        return $this->lastError;
     }
 }

--- a/tests/Gelf/Test/Transport/IgnoreErrorTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/IgnoreErrorTransportWrapperTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Gelf\Test\Transport;
+
+use Gelf\Message;
+use Gelf\TestCase;
+use Gelf\Transport\AbstractTransport;
+use Gelf\Transport\IgnoreErrorTransportWrapper;
+use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+
+class IgnoreErrorTransportWrapperTest extends TestCase
+{
+    public function testSend()
+    {
+        $expectedMessage = $this->buildMessage();
+
+        $transport = $this->buildTransport();
+        $wrapper   = new IgnoreErrorTransportWrapper($transport);
+
+        $transport->expects($this->once())
+                  ->method('send')
+                  ->with($expectedMessage)
+                  ->willThrowException(new \RuntimeException());
+
+        $bytes = $wrapper->send($expectedMessage);
+
+        $this->assertEquals(0, $bytes);
+    }
+
+    /**
+     * @return MockObject|AbstractTransport
+     */
+    private function buildTransport()
+    {
+        return $this->getMockForAbstractClass("\\Gelf\\Transport\\AbstractTransport");
+    }
+
+    /**
+     * @return MockObject|Message
+     */
+    private function buildMessage()
+    {
+        return $this->getMockForAbstractClass("\\Gelf\\Message");
+    }
+}

--- a/tests/Gelf/Test/Transport/IgnoreErrorTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/IgnoreErrorTransportWrapperTest.php
@@ -12,7 +12,8 @@ class IgnoreErrorTransportWrapperTest extends TestCase
 {
     public function testSend()
     {
-        $expectedMessage = $this->buildMessage();
+        $expectedMessage   = $this->buildMessage();
+        $expectedException = new \RuntimeException();
 
         $transport = $this->buildTransport();
         $wrapper   = new IgnoreErrorTransportWrapper($transport);
@@ -20,11 +21,13 @@ class IgnoreErrorTransportWrapperTest extends TestCase
         $transport->expects($this->once())
                   ->method('send')
                   ->with($expectedMessage)
-                  ->willThrowException(new \RuntimeException());
+                  ->willThrowException($expectedException);
 
         $bytes = $wrapper->send($expectedMessage);
+        $lastError = $wrapper->getLastError();
 
         $this->assertEquals(0, $bytes);
+        $this->assertSame($expectedException, $lastError);
     }
 
     /**


### PR DESCRIPTION
A wrapper for any AbstractTransport to ignore any kind of errors.

Fix #56 