### PR TITLE
Very simple "dependency injection" for Message instance

### DIFF
--- a/src/Gelf/Logger.php
+++ b/src/Gelf/Logger.php
@@ -112,6 +112,9 @@ class Logger extends AbstractLogger implements LoggerInterface
     }
 
     /**
+     * Override this function to inject a different
+     * \Gelf\Message instance into the logger
+     *
      * @return Message
      */
     protected function createMessage()

--- a/tests/Gelf/Test/LoggerTest.php
+++ b/tests/Gelf/Test/LoggerTest.php
@@ -45,15 +45,15 @@ class LoggerTest extends TestCase
     public function testCustomMessageClass()
     {
         $message = $this->getMockBuilder('\Gelf\Test\Message\CustomMessage')
-            ->setMethods(['getAdditionalPrefix'])
+            ->setMethods(array('getAdditionalPrefix'))
             ->getMock();
 
         $message->method('getAdditionalPrefix')
             ->willReturn('myprefix_');
 
         $logger = $this->getMockBuilder('\Gelf\Logger')
-                ->setConstructorArgs([$this->publisher, $this->facility])
-                ->setMethods(['publish', 'createMessage'])
+                ->setConstructorArgs(array($this->publisher, $this->facility))
+                ->setMethods(array('publish', 'createMessage'))
                 ->getMock();
 
         $logger->method('createMessage')
@@ -70,7 +70,7 @@ class LoggerTest extends TestCase
         );
 
         /** @var Logger $logger */
-        $logger->log(LogLevel::ALERT, "test", ["foo" => "bar"]);
+        $logger->log(LogLevel::ALERT, "test", array("foo" => "bar"));
     }
 
     public function testPublisher()

--- a/tests/Gelf/Test/Message/CustomMessage.php
+++ b/tests/Gelf/Test/Message/CustomMessage.php
@@ -1,0 +1,40 @@
+<?php
+namespace Gelf\Test\Message;
+
+use Gelf\Message;
+
+class CustomMessage extends Message
+{
+    /** @var string */
+    protected $additionalPrefix;
+
+    /**
+     * @return string
+     */
+    public function getAdditionalPrefix()
+    {
+        return $this->additionalPrefix;
+    }
+
+    /**
+     * @param string $additionalPrefix
+     *
+     * @return static
+     */
+    public function setAdditionalPrefix($additionalPrefix)
+    {
+        $this->additionalPrefix = $additionalPrefix;
+        return $this;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setAdditional($key, $value)
+    {
+        return parent::setAdditional("{$this->getAdditionalPrefix()}{$key}", $value);
+    }
+}


### PR DESCRIPTION
If one wanted to extend the `Message` class and add additional fields, etc - currently it would require copying the `\Gelf\Logger::initMessage` function and changing the instantiation.

What I've implemented here is a very simple method of overriding the `Message` class used if one extends the `Logger` class.

Obviously something more robust could be put in place - this is just a quick 5-min thought :)
