### PR TITLE
Update HttpTransport.php

### DIFF
--- a/src/Gelf/Transport/HttpTransport.php
+++ b/src/Gelf/Transport/HttpTransport.php
@@ -121,7 +121,7 @@ class HttpTransport extends AbstractTransport
          
         // merge defaults and real data and build transport
         $parsed = array_merge($defaults, $parsed);
-        $transport = new self($parsed['host'], $parsed['port'], $parsed['path'], $sslOptions);
+        $transport = new static($parsed['host'], $parsed['port'], $parsed['path'], $sslOptions);
 
         // add optional authentication
         if ($parsed['user']) {


### PR DESCRIPTION
I wanted to create a subclass from `HttpTransport` and had issues with its static `fromUrl` method. I found out that `new self` was the problem. It only creates a new instance from itself, not respecting the class hierachy.