### PR TITLE
Do not throw exception on write for udp socket.

### DIFF
--- a/src/Gelf/Transport/StreamSocketClient.php
+++ b/src/Gelf/Transport/StreamSocketClient.php
@@ -219,7 +219,9 @@ class StreamSocketClient
 
 
             if ($failed || $byteCount === false) {
-                throw new \RuntimeException($errorMessage);
+                if ($this->scheme !== 'udp') {
+                    throw new \RuntimeException($errorMessage);
+                }
             }
 
 


### PR DESCRIPTION
At the moment if we send log in udp and for some reason the server is down or the connection is refused we are throwing an exception.

This is mainly because we can receive a UDP Port Unreachable.

It may seems bad to avoid throwing the exception but when sending logs in udp we accept the idea that some logs might not be sent ! Also we do have the number of bytes written which should be equal to 0. At the moment the problem I face is that I log locally and in graylog so I don't want to be jamming my application just because the logs are not beeing sent.

If it seems a bit unreasonable not to throw an exception by default perhaps we could change the definition of the method to:

    ```public function write($buffer, $throwable = true)```

