### PR TITLE
Added option for nested arrays in a message

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -300,7 +300,7 @@ class Message implements MessageInterface
 
         // return after filtering empty strings and null values
         return array_filter($message, function ($message) {
-            return is_bool($message) || strlen($message);
+            return is_array($message) || is_bool($message) || strlen($message);
         });
     }
 }


### PR DESCRIPTION
@bzikarsky This commit will add the functionality to be able to have nested arrays inside a message, either in the _full_message_ or in an additional field in the GELF message.

I had a problem trying to log nested arrays, where they would be represented in Graylog2 as PHP arrays, see below for an example, instead of JSON objects.

![php array instead of json object](https://cloud.githubusercontent.com/assets/10833733/25237875/1dcf2b60-25ec-11e7-9274-a02a78060a3f.png)

After adding this commit, it works as expected: adding nested arrays as JSON objects, instead of their original PHP representation.

If there's any questions/suggestions I'm happy to hear them.

Have a nice day. :)