### PR TITLE
Ability to specify socket scheme in TcpTransport

### DIFF
--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -29,6 +29,7 @@ class TcpTransport extends AbstractTransport
 {
     const DEFAULT_HOST = "127.0.0.1";
     const DEFAULT_PORT = 12201;
+    const DEFAULT_SCHEME = 'tcp';
 
     /**
      * @var StreamSocketClient
@@ -41,13 +42,13 @@ class TcpTransport extends AbstractTransport
      * @param string $host      when NULL or empty DEFAULT_HOST is used
      * @param int    $port      when NULL or empty DEFAULT_PORT is used
      */
-    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT)
+    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $scheme = self::DEFAULT_SCHEME)
     {
         // allow NULL-like values for fallback on default
         $host = $host ?: self::DEFAULT_HOST;
         $port = $port ?: self::DEFAULT_PORT;
 
-        $this->socketClient = new StreamSocketClient('tcp', $host, $port);
+        $this->socketClient = new StreamSocketClient($scheme, $host, $port);
         $this->messageEncoder = new DefaultEncoder();
     }
 

--- a/tests/Gelf/Test/Transport/TcpTransportTest.php
+++ b/tests/Gelf/Test/Transport/TcpTransportTest.php
@@ -122,4 +122,30 @@ class TcpTransportTest extends TestCase
 
         $this->transport->setConnectTimeout(123);
     }
+
+    private function getScheme($transport)
+    {
+        $reflectedTransport = new \ReflectionObject($transport);
+        $reflectedClient = $reflectedTransport->getProperty('socketClient');
+        $reflectedClient->setAccessible(true);
+
+        $socketClient = $reflectedClient->getValue($transport);
+        $reflectedSocketClient = new \ReflectionObject($socketClient);
+        $reflectedScheme = $reflectedSocketClient->getProperty('scheme');
+        $reflectedScheme->setAccessible(true);
+
+        return $reflectedScheme->getValue($socketClient);
+    }
+
+    public function testCustomScheme()
+    {
+        $transport = new TcpTransport(null, null, 'custom');
+        $this->assertEquals('custom', $this->getScheme($transport));
+    }
+
+    public function testDefaultScheme()
+    {
+        $transport = new TcpTransport(null, null);
+        $this->assertEquals('tcp', $this->getScheme($transport));
+    }
 }


### PR DESCRIPTION
This can be useful if there's no HTTPS support and when you have to use a `ssl` scheme (e.g. OVH's Graylog only allows TCP, UDP, TCP/ssl and not HTTPS https://docs.ovh.com/gb/en/mobile-hosting/logs-data-platform/quick-start/#id2)