### PR TITLE
Improve tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr/log-implementation": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.3",
+        "phpunit/phpunit": "~4.8.36",
         "squizlabs/php_codesniffer": "~2.0"
     },
     "extra": {

--- a/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Encoder;
 
 use Gelf\Encoder\CompressedJsonEncoder;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class CompressedJsonEncoderTest extends TestCase
 {

--- a/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
@@ -49,11 +49,11 @@ class CompressedJsonEncoderTest extends TestCase
 
         // check that it's uncompressable
         $json = gzuncompress($bytes);
-        $this->assertTrue(is_string($json));
+        $this->assertInternalType('string', $json);
 
         // check that there is JSON inside
         $data = json_decode($json, $assoc = true);
-        $this->assertTrue(is_array($data));
+        $this->assertInternalType('array', $data);
 
         // check that we have our data array
         $this->assertEquals($testData, $data);

--- a/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/CompressedJsonEncoderTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Encoder;
 
 use Gelf\Encoder\CompressedJsonEncoder;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class CompressedJsonEncoderTest extends TestCase
 {

--- a/tests/Gelf/Test/Encoder/JsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/JsonEncoderTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Encoder;
 
 use Gelf\Encoder\JsonEncoder;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class JsonEncoderTest extends TestCase
 {

--- a/tests/Gelf/Test/Encoder/JsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/JsonEncoderTest.php
@@ -46,7 +46,7 @@ class JsonEncoderTest extends TestCase
 
         // check that there is JSON inside
         $data = json_decode($json, $assoc = true);
-        $this->assertTrue(is_array($data));
+        $this->assertInternalType('array', $data);
 
         // check that we have our data array
         $this->assertEquals($testData, $data);

--- a/tests/Gelf/Test/Encoder/JsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/JsonEncoderTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Encoder;
 
 use Gelf\Encoder\JsonEncoder;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class JsonEncoderTest extends TestCase
 {

--- a/tests/Gelf/Test/LoggerTest.php
+++ b/tests/Gelf/Test/LoggerTest.php
@@ -14,7 +14,7 @@ namespace Gelf\Test;
 use Gelf\Logger;
 use Gelf\MessageInterface;
 use Gelf\PublisherInterface;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Exception;
 use Closure;

--- a/tests/Gelf/Test/LoggerTest.php
+++ b/tests/Gelf/Test/LoggerTest.php
@@ -14,7 +14,7 @@ namespace Gelf\Test;
 use Gelf\Logger;
 use Gelf\MessageInterface;
 use Gelf\PublisherInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Psr\Log\LogLevel;
 use Exception;
 use Closure;

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\Message;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 use Psr\Log\LogLevel;
 
 class MessageTest extends TestCase

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\Message;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 
 class MessageTest extends TestCase

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -30,8 +30,8 @@ class MessageTest extends TestCase
 
     public function testTimestamp()
     {
-        $this->assertTrue(microtime(true) >= $this->message->getTimestamp());
-        $this->assertTrue(0 < $this->message->getTimestamp());
+        $this->assertLessThanOrEqual(microtime(true), $this->message->getTimestamp());
+        $this->assertGreaterThan(0, $this->message->getTimestamp());
 
         $this->message->setTimestamp(123);
         $this->assertEquals(123, $this->message->getTimestamp());
@@ -134,18 +134,18 @@ class MessageTest extends TestCase
 
     public function testAdditionals()
     {
-        $this->assertTrue(is_array($this->message->getAllAdditionals()));
-        $this->assertTrue(0 == count($this->message->getAllAdditionals()));
+        $this->assertInternalType('array', $this->message->getAllAdditionals());
+        $this->assertCount(0, $this->message->getAllAdditionals());
 
         $this->assertFalse($this->message->hasAdditional("foo"));
         $this->message->setAdditional("foo", "bar");
         $this->assertEquals("bar", $this->message->getAdditional("foo"));
         $this->assertTrue($this->message->hasAdditional("foo"));
-        $this->assertTrue(1 == count($this->message->getAllAdditionals()));
+        $this->assertCount(1, $this->message->getAllAdditionals());
 
         $this->message->setAdditional("foo", "buk");
         $this->assertEquals("buk", $this->message->getAdditional("foo"));
-        $this->assertTrue(1 == count($this->message->getAllAdditionals()));
+        $this->assertCount(1, $this->message->getAllAdditionals());
 
         $this->assertEquals(
             array("foo" => "buk"),
@@ -200,7 +200,7 @@ class MessageTest extends TestCase
         $this->message->setAdditional("bool-true", true);
         $this->message->setAdditional("bool-false", false);
         $data = $this->message->toArray();
-        $this->assertTrue(is_array($data));
+        $this->assertInternalType('array', $data);
 
         // test additionals
         $this->assertArrayHasKey("_foo", $data);
@@ -209,7 +209,7 @@ class MessageTest extends TestCase
         $this->assertTrue($data["_bool-true"]);
         $this->assertArrayHasKey("_bool-false", $data);
         $this->assertFalse($data["_bool-false"]);
-        
+
         $map = array(
             "version"       => "getVersion",
             "host"          => "getHost",
@@ -231,7 +231,7 @@ class MessageTest extends TestCase
                     $method,
                     $k
                 );
-                $this->assertFalse(array_key_exists($k, $data), $error);
+                $this->assertArrayNotHasKey($k, $data, $error);
             } else {
                 $this->assertEquals($data[$k], $this->message->$method());
             }

--- a/tests/Gelf/Test/MessageValidatorTest.php
+++ b/tests/Gelf/Test/MessageValidatorTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\MessageValidator;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class MessageValidatorTest extends TestCase
 {

--- a/tests/Gelf/Test/MessageValidatorTest.php
+++ b/tests/Gelf/Test/MessageValidatorTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\MessageValidator;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class MessageValidatorTest extends TestCase
 {

--- a/tests/Gelf/Test/PublisherTest.php
+++ b/tests/Gelf/Test/PublisherTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\Publisher;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class PublisherTest extends TestCase
 {

--- a/tests/Gelf/Test/PublisherTest.php
+++ b/tests/Gelf/Test/PublisherTest.php
@@ -68,7 +68,7 @@ class PublisherTest extends TestCase
     public function testMissingTransport()
     {
         $publisher = new Publisher(null, $this->messageValidator);
-        $this->assertEquals(0, count($publisher->getTransports()));
+        $this->assertCount(0, $publisher->getTransports());
 
         $publisher->publish($this->message);
     }
@@ -95,16 +95,16 @@ class PublisherTest extends TestCase
     public function testGetTransports()
     {
         $pub = new Publisher(null, $this->messageValidator);
-        $this->assertEquals(0, count($pub->getTransports()));
+        $this->assertCount(0, $pub->getTransports());
 
         $pub->addTransport($this->transportA);
-        $this->assertEquals(1, count($pub->getTransports()));
+        $this->assertCount(1, $pub->getTransports());
 
         $pub->addTransport($this->transportB);
-        $this->assertEquals(2, count($pub->getTransports()));
+        $this->assertCount(2, $pub->getTransports());
 
         $pub->addTransport($this->transportA);
-        $this->assertEquals(2, count($pub->getTransports()));
+        $this->assertCount(2, $pub->getTransports());
     }
 
     public function testInitWithDefaultValidator()

--- a/tests/Gelf/Test/PublisherTest.php
+++ b/tests/Gelf/Test/PublisherTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test;
 
 use Gelf\Publisher;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class PublisherTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/AmqpTransportTest.php
+++ b/tests/Gelf/Test/Transport/AmqpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\AmqpTransport;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class AmqpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/AmqpTransportTest.php
+++ b/tests/Gelf/Test/Transport/AmqpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\AmqpTransport;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class AmqpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/HttpTransportTest.php
+++ b/tests/Gelf/Test/Transport/HttpTransportTest.php
@@ -13,7 +13,7 @@ namespace Gelf\Test\Transport;
 
 use Gelf\Transport\HttpTransport;
 use Gelf\Transport\SslOptions;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class HttpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/HttpTransportTest.php
+++ b/tests/Gelf/Test/Transport/HttpTransportTest.php
@@ -13,7 +13,7 @@ namespace Gelf\Test\Transport;
 
 use Gelf\Transport\HttpTransport;
 use Gelf\Transport\SslOptions;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class HttpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/StreamSocketClientTcpTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientTcpTest.php
@@ -65,7 +65,7 @@ class StreamSocketClientTcpTest extends TestCase
 
     public function testGetSocket()
     {
-        $this->assertTrue(is_resource($this->socketClient->getSocket()));
+        $this->assertInternalType('resource', $this->socketClient->getSocket());
     }
 
     public function testWrite()

--- a/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
@@ -68,7 +68,7 @@ class StreamSocketClientUdpTest extends TestCase
 
     public function testGetSocket()
     {
-        $this->assertTrue(is_resource($this->socketClient->getSocket()));
+        $this->assertInternalType('resource', $this->socketClient->getSocket());
     }
 
     public function testWrite()

--- a/tests/Gelf/Test/Transport/TcpTransportTest.php
+++ b/tests/Gelf/Test/Transport/TcpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\TcpTransport;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class TcpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/TcpTransportTest.php
+++ b/tests/Gelf/Test/Transport/TcpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\TcpTransport;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class TcpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/UdpTransportTest.php
+++ b/tests/Gelf/Test/Transport/UdpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\UdpTransport;
-use PHPUnit\Framework\TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 class UdpTransportTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/UdpTransportTest.php
+++ b/tests/Gelf/Test/Transport/UdpTransportTest.php
@@ -12,7 +12,7 @@
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\UdpTransport;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase as TestCase;
 
 class UdpTransportTest extends TestCase
 {

--- a/tests/Gelf/TestCase.php
+++ b/tests/Gelf/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Gelf;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
 
     public function failsOnHHVM()


### PR DESCRIPTION
Using PHPUnit dedicated assertions will give us better error messages, making easier to debug fails. For example:
```diff
-$this->assertTrue(in_array('foo', ['bar', 'baz']));
+$this->assertContains('foo', ['baz', 'bar']);
```

Will give us:
```diff
-Failed asserting that false is true.
+Failed asserting that an array contains 'foo'.
```

I've also used the namespaced PHPUnit TestCase, as it was removed in future versions of PHPUnit. [`4.8.36` was the first one](https://github.com/sebastianbergmann/phpunit/blob/4.8/ChangeLog-4.8.md#4836---2017-06-21) compatible.