### PR TITLE
Allow encryption for TCP transport

### DIFF
--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -40,14 +40,15 @@ class TcpTransport extends AbstractTransport
      *
      * @param string $host      when NULL or empty DEFAULT_HOST is used
      * @param int    $port      when NULL or empty DEFAULT_PORT is used
+	 * @param string $scheme    Allowed scheme for stream sockets, e.g. 'tcp' or 'tls'
      */
-    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT)
+    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $scheme = 'tcp')
     {
         // allow NULL-like values for fallback on default
         $host = $host ?: self::DEFAULT_HOST;
         $port = $port ?: self::DEFAULT_PORT;
 
-        $this->socketClient = new StreamSocketClient('tcp', $host, $port);
+        $this->socketClient = new StreamSocketClient($scheme, $host, $port);
         $this->messageEncoder = new DefaultEncoder();
     }
 


### PR DESCRIPTION
Currently, TCP transport uses a PHP stream socket to transmit messages, which is hardcoded to use a 'tcp' scheme. Some graylog instanbces (e.g. hosted graylog by OVH) allow submission of messages via TCP+TLS (but not via HTTP[S]). In these cases one needs to be able to modify the stream socket scheme to force SSL/TLS.