### PR TITLE
Allow TLS with TCP transport

### DIFF
--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -40,14 +40,15 @@ class TcpTransport extends AbstractTransport
      *
      * @param string $host      when NULL or empty DEFAULT_HOST is used
      * @param int    $port      when NULL or empty DEFAULT_PORT is used
+     * @param string $scheme    Allowed scheme for stream sockets, e.g. 'tcp' or 'tls'
      */
-    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT)
+    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT, $scheme = 'tcp')
     {
         // allow NULL-like values for fallback on default
         $host = $host ?: self::DEFAULT_HOST;
         $port = $port ?: self::DEFAULT_PORT;
 
-        $this->socketClient = new StreamSocketClient('tcp', $host, $port);
+        $this->socketClient = new StreamSocketClient($scheme, $host, $port);
         $this->messageEncoder = new DefaultEncoder();
     }
 


### PR DESCRIPTION
Some Graylog instances (e.g. hosted from OVH) have TCP endpoints with TLS enabled. Currently, this library has no option for encrypted TCP transport (only for HTTPS).