### PR TITLE
Add Support for SslOptions in TcpTransport

### DIFF
--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -13,11 +13,10 @@ namespace Gelf\Transport;
 
 use Gelf\MessageInterface as Message;
 use Gelf\Encoder\JsonEncoder as DefaultEncoder;
-use RuntimeException;
 
 /**
- * TcpTransport allows the transfer of GELF-messages to an compatible
- * GELF-TCP-backend as described in
+ * TcpTransport allows the transfer of GELF-messages (with SSL/TLS support)
+ * to a compatible GELF-TCP-backend as described in
  * https://github.com/Graylog2/graylog2-docs/wiki/GELF
  *
  * It can also act as a direct publisher
@@ -30,25 +29,56 @@ class TcpTransport extends AbstractTransport
     const DEFAULT_HOST = "127.0.0.1";
     const DEFAULT_PORT = 12201;
 
+    const AUTO_SSL_PORT = 12202;
+
+    /**
+     * @var string
+     */
+    protected $host;
+
+    /**
+     * @var int
+     */
+    protected $port;
+
     /**
      * @var StreamSocketClient
      */
     protected $socketClient;
 
     /**
+     * @var SslOptions|null
+     */
+    protected $sslOptions = null;
+
+    /**
      * Class constructor
      *
-     * @param string $host      when NULL or empty DEFAULT_HOST is used
-     * @param int    $port      when NULL or empty DEFAULT_PORT is used
+     * @param string|null     $host       when NULL or empty default-host is used
+     * @param int|null        $port       when NULL or empty default-port is used
+     * @param SslOptions|null $sslOptions when null not SSL is used
      */
-    public function __construct($host = self::DEFAULT_HOST, $port = self::DEFAULT_PORT)
-    {
-        // allow NULL-like values for fallback on default
-        $host = $host ?: self::DEFAULT_HOST;
-        $port = $port ?: self::DEFAULT_PORT;
+    public function __construct(
+        $host = self::DEFAULT_HOST,
+        $port = self::DEFAULT_PORT,
+        SslOptions $sslOptions = null
+    ) {
+        $this->host = $host;
+        $this->port = $port;
 
-        $this->socketClient = new StreamSocketClient('tcp', $host, $port);
+        if ($port == self::AUTO_SSL_PORT && $sslOptions == null) {
+            $sslOptions = new SslOptions();
+        }
+
+        $this->sslOptions = $sslOptions;
+
         $this->messageEncoder = new DefaultEncoder();
+        $this->socketClient = new StreamSocketClient(
+            $this->getScheme(),
+            $this->host,
+            $this->port,
+            $this->getContext()
+        );
     }
 
     /**
@@ -61,11 +91,31 @@ class TcpTransport extends AbstractTransport
     public function send(Message $message)
     {
         $rawMessage = $this->getMessageEncoder()->encode($message) . "\0";
-        
+
         // send message in one packet
         $this->socketClient->write($rawMessage);
 
         return 1;
+    }
+
+    /**
+     * @return string
+     */
+    private function getScheme()
+    {
+        return null === $this->sslOptions ? 'tcp' : 'ssl';
+    }
+
+    /**
+     * @return array
+     */
+    private function getContext()
+    {
+        if (null === $this->sslOptions) {
+            return array();
+        }
+
+        return $this->sslOptions->toStreamContext($this->host);
     }
 
     /**


### PR DESCRIPTION
Ported support for SslOptions from HttpTransport to TcpTransport, so also plain TCP messages can be sent encrypted.