### PR TITLE
Fix PHP notice with PHP > 5.5

### DIFF
--- a/src/Gelf/Transport/SslOptions.php
+++ b/src/Gelf/Transport/SslOptions.php
@@ -156,7 +156,7 @@ class SslOptions
             $sslContext[PHP_VERSION_ID < 50600 ? 'SNI_server_name' : 'peer_name'] = $serverName;
 
             if ($this->verifyPeer) {
-                $sslContext['CN_match'] = $serverName;
+                $sslContext[PHP_VERSION_ID < 50600 ? 'CN_match' : 'peer_name'] = $serverName;
             }
         }
 

--- a/tests/Gelf/Test/Transport/SslOptionsTest.php
+++ b/tests/Gelf/Test/Transport/SslOptionsTest.php
@@ -77,7 +77,8 @@ class SslOptionsTest extends TestCase
     public function testToStreamContextWithHostname()
     {
         $options = new SslOptions();
-        $peerNameKey = PHP_VERSION_ID < 50600 ? 'SNI_server_name' : 'peer_name';
+        $peerNameKey = PHP_VERSION_ID < 50600 ? 'CN_match' : 'peer_name';
+        $sniPeerNameKey = PHP_VERSION_ID < 50600 ? 'SNI_server_name' : 'peer_name';
         $host = 'test.local';
 
         $options->setVerifyPeer(false);
@@ -86,10 +87,10 @@ class SslOptionsTest extends TestCase
         $this->assertArrayHasKey('ssl', $context);
         $this->assertArrayHasKey('SNI_enabled', $context['ssl']);
         $this->assertArrayNotHasKey('CN_match', $context['ssl']);
-        $this->assertArrayHasKey($peerNameKey, $context['ssl']);
+        $this->assertArrayHasKey($sniPeerNameKey, $context['ssl']);
 
         $this->assertEquals(true, $context['ssl']['SNI_enabled']);
-        $this->assertEquals($host, $context['ssl'][$peerNameKey]);
+        $this->assertEquals($host, $context['ssl'][$sniPeerNameKey]);
 
 
         $options->setVerifyPeer(true);
@@ -97,11 +98,11 @@ class SslOptionsTest extends TestCase
 
         $this->assertArrayHasKey('ssl', $context);
         $this->assertArrayHasKey('SNI_enabled', $context['ssl']);
-        $this->assertArrayHasKey('CN_match', $context['ssl']);
         $this->assertArrayHasKey($peerNameKey, $context['ssl']);
+        $this->assertArrayHasKey($sniPeerNameKey, $context['ssl']);
 
         $this->assertEquals(true, $context['ssl']['SNI_enabled']);
-        $this->assertEquals($host, $context['ssl']['CN_match']);
         $this->assertEquals($host, $context['ssl'][$peerNameKey]);
+        $this->assertEquals($host, $context['ssl'][$sniPeerNameKey]);
     }
 }


### PR DESCRIPTION
CN_match is deprecated in PHP 5.6 - peer_name should be used instead. From 5.6. the SNI options + the additional hostname for "verifyPeer" are somewhat redundant, but left it in for now to support PHP < 5.6 with the old constant name "CN_match".