### PR TITLE
 Fix Message toArray empty validation for zero int values

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -302,6 +302,7 @@ class Message implements MessageInterface
         return array_filter($message, function ($message) {
             return is_bool($message)
                 || (is_string($message) && strlen($message))
+                || is_int($message)
                 || !empty($message);
         });
     }

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -199,6 +199,7 @@ class MessageTest extends TestCase
         $this->message->setAdditional("foo", "bar");
         $this->message->setAdditional("bool-true", true);
         $this->message->setAdditional("bool-false", false);
+        $this->message->setAdditional("int-zero", 0);
         $data = $this->message->toArray();
         $this->assertInternalType('array', $data);
 
@@ -209,6 +210,8 @@ class MessageTest extends TestCase
         $this->assertTrue($data["_bool-true"]);
         $this->assertArrayHasKey("_bool-false", $data);
         $this->assertFalse($data["_bool-false"]);
+        $this->assertArrayHasKey("_int-zero", $data);
+        $this->assertEquals(0, $data["_int-zero"]);
 
         $map = array(
             "version"       => "getVersion",
@@ -279,6 +282,7 @@ class MessageTest extends TestCase
         $this->message->setAdditional("foo", "bar");
         $this->message->setAdditional("bool-true", true);
         $this->message->setAdditional("bool-false", false);
+        $this->message->setAdditional("int-zero", 0);
 
         // check that deperacted behaviour is overridden in 1.1
         $this->message->setLine(50);
@@ -305,5 +309,7 @@ class MessageTest extends TestCase
         $this->assertTrue($data["_bool-true"]);
         $this->assertArrayHasKey("_bool-false", $data);
         $this->assertFalse($data["_bool-false"]);
+        $this->assertArrayHasKey("_int-zero", $data);
+        $this->assertEquals(0, $data["_int-zero"]);
     }
 }


### PR DESCRIPTION
The toArray function in the Message class filters out `0` values in the additional fields because of the `!empty($message)` validation since PR #94. I've fixed this by checking for integers before the `empty` validation and added a `0` value to the test cases.