### PR TITLE
Custom service needs level param to be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ You only need to properly define the symfony-service `gelf-handler`:
 services:
   monolog.gelf_handler:
     class: Monolog\Handler\GelfHandler
-    arguments: [@gelf.publisher]
+    arguments:
+        - @gelf.publisher
+        - 'warning' #monolog config is ignored with custom service level has to be redefined here (default : debug), you should probably use parameters eg: '%gelf_level%'
     
   gelf.publisher:
     class: Gelf\Publisher


### PR DESCRIPTION
With custom service definition, config level param in monolog section is no longer used, so if expected level is not debug, it could be useful to show in documentation how to override it with service arguments.