### PR TITLE
no escape unicode

### DIFF
--- a/src/Gelf/Encoder/JsonEncoder.php
+++ b/src/Gelf/Encoder/JsonEncoder.php
@@ -21,18 +21,137 @@ use Gelf\MessageInterface;
  */
 class JsonEncoder implements NoNullByteEncoderInterface
 {
+
     /**
      * Encodes a given message
      *
-     * @param  MessageInterface $message
+     * @param MessageInterface $message
      * @return string
      */
     public function encode(MessageInterface $message)
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
-            return json_encode($message->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
-        }
+        return $this->toJson($message->toArray());
+    }
 
-        return json_encode($message->toArray());
+    /**
+     * Return the JSON representation of a value
+     *
+     * @param mixed $data
+     * @return string
+     * @throws \RuntimeException if encoding fails and errors are not ignored
+     */
+    protected function toJson($data)
+    {
+        $json = $this->jsonEncode($data);
+        if ($json === false) {
+            $json = $this->handleJsonError(json_last_error(), $data);
+        }
+        return $json;
+    }
+
+    /**
+     * @param mixed $data
+     * @return string JSON encoded data or null on failure
+     */
+    private function jsonEncode($data)
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            return json_encode($data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+        return json_encode($data);
+    }
+
+    /**
+     * Handle a json_encode failure.
+     *
+     * If the failure is due to invalid string encoding, try to clean the
+     * input and encode again. If the second encoding attempt fails, the
+     * inital error is not encoding related or the input can't be cleaned then
+     * raise a descriptive exception.
+     *
+     * @param int $code return code of json_last_error function
+     * @param mixed $data data that was meant to be encoded
+     * @return string            JSON encoded data after error correction
+     * @throws \RuntimeException if failure can't be corrected
+     */
+    private function handleJsonError($code, $data)
+    {
+        if ($code !== JSON_ERROR_UTF8) {
+            $this->throwEncodeError($code, $data);
+        }
+        if (is_string($data)) {
+            $this->detectAndCleanUtf8($data);
+        } elseif (is_array($data)) {
+            array_walk_recursive($data, array($this, 'detectAndCleanUtf8'));
+        } else {
+            $this->throwEncodeError($code, $data);
+        }
+        $json = $this->jsonEncode($data);
+        if ($json === false) {
+            $this->throwEncodeError(json_last_error(), $data);
+        }
+        return $json;
+    }
+
+    /**
+     * Throws an exception according to a given code with a customized message
+     *
+     * @param int $code return code of json_last_error function
+     * @param mixed $data data that was meant to be encoded
+     * @throws \RuntimeException
+     */
+    private function throwEncodeError($code, $data)
+    {
+        switch ($code) {
+            case JSON_ERROR_DEPTH:
+                $msg = 'Maximum stack depth exceeded';
+                break;
+            case JSON_ERROR_STATE_MISMATCH:
+                $msg = 'Underflow or the modes mismatch';
+                break;
+            case JSON_ERROR_CTRL_CHAR:
+                $msg = 'Unexpected control character found';
+                break;
+            case JSON_ERROR_UTF8:
+                $msg = 'Malformed UTF-8 characters, possibly incorrectly encoded';
+                break;
+            default:
+                $msg = 'Unknown error';
+        }
+        throw new \RuntimeException('JSON encoding failed: ' . $msg . '. Encoding: ' . var_export($data, true));
+    }
+
+    /**
+     * Detect invalid UTF-8 string characters and convert to valid UTF-8.
+     *
+     * Valid UTF-8 input will be left unmodified, but strings containing
+     * invalid UTF-8 codepoints will be reencoded as UTF-8 with an assumed
+     * original encoding of ISO-8859-15. This conversion may result in
+     * incorrect output if the actual encoding was not ISO-8859-15, but it
+     * will be clean UTF-8 output and will not rely on expensive and fragile
+     * detection algorithms.
+     *
+     * Function converts the input in place in the passed variable so that it
+     * can be used as a callback for array_walk_recursive.
+     *
+     * @param mixed &$data Input to check and convert if needed
+     * @private
+     */
+    public function detectAndCleanUtf8(&$data)
+    {
+        if (is_string($data) && !preg_match('//u', $data)) {
+            $data = preg_replace_callback(
+                '/[\x80-\xFF]+/',
+                function ($m) {
+                    return utf8_encode($m[0]);
+                },
+                $data
+            );
+            $data = str_replace(
+                array('¤', '¦', '¨', '´', '¸', '¼', '½', '¾'),
+                array('€', 'Š', 'š', 'Ž', 'ž', 'Œ', 'œ', 'Ÿ'),
+                $data
+            );
+        }
     }
 }

--- a/src/Gelf/Encoder/JsonEncoder.php
+++ b/src/Gelf/Encoder/JsonEncoder.php
@@ -29,6 +29,10 @@ class JsonEncoder implements NoNullByteEncoderInterface
      */
     public function encode(MessageInterface $message)
     {
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            return json_encode($message->toArray(), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        }
+
         return json_encode($message->toArray());
     }
 }

--- a/tests/Gelf/Test/Encoder/JsonEncoderTest.php
+++ b/tests/Gelf/Test/Encoder/JsonEncoderTest.php
@@ -51,4 +51,23 @@ class JsonEncoderTest extends TestCase
         // check that we have our data array
         $this->assertEquals($testData, $data);
     }
+
+    public function testUnicodeEncode()
+    {
+        $testData = array('foo' => 'бар');
+
+        $this->message
+            ->expects($this->once())
+            ->method('toArray')
+            ->will($this->returnValue($testData));
+
+        $json = $this->encoder->encode($this->message);
+
+        if (version_compare(PHP_VERSION, '5.4.0', '>=')) {
+            $this->assertEquals('{"foo":"бар"}', $json);
+        } else {
+            $this->assertEquals('{"foo":"\u0431\u0430\u0440"}', $json);
+        }
+
+    }
 }


### PR DESCRIPTION
this is part ported from https://github.com/Seldaek/monolog/blob/1.x/src/Monolog/Formatter/NormalizerFormatter.php

this change need to correct calculate Content-Length of message in HttpTransport::send

The same way, such as GelfMessageFormatter in monolog