### PR TITLE
Allows falsy strings (eg "0") as context key

### DIFF
--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -256,7 +256,8 @@ class Message implements MessageInterface
 
     public function setAdditional($key, $value)
     {
-        if (!$key) {
+        $key = (string)$key;
+        if ($key === '') {
             throw new RuntimeException("Additional field key cannot be empty");
         }
 

--- a/tests/Gelf/Test/MessageTest.php
+++ b/tests/Gelf/Test/MessageTest.php
@@ -160,6 +160,13 @@ class MessageTest extends TestCase
     {
         $this->message->setAdditional("", "test");
     }
+    public function testSetZeroKey()
+    {
+        $key = 0;
+        $value = 'zero';
+        $this->message->setAdditional($key, $value);
+        $this->assertEquals($value, $this->message->getAdditional($key));
+    }
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
Currently `$context = ['test','test'];` throws runtime exception because "0" is falsy. 