### PR TITLE
Add retry wrapper to allow reconnect when the socket in HttpTransport is closed

### DIFF
--- a/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
+++ b/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
@@ -2,70 +2,19 @@
 
 namespace Gelf\Transport;
 
-use Gelf\MessageInterface as Message;
+use RuntimeException;
 
-class KeepAliveRetryTransportWrapper extends AbstractTransport
+class KeepAliveRetryTransportWrapper extends RetryTransportWrapper
 {
     /**
      * @const string
      */
     const NO_RESPONSE = "Graylog-Server didn't answer properly, expected 'HTTP/1.x 202 Accepted', response is ''";
 
-    /**
-     * @var HttpTransport
-     */
-    protected $transport;
-
-    /**
-     * @var int
-     */
-    protected $maxRetries;
-
-    /**
-     * @var int
-     */
-    protected $incrementedRetries = 0;
-
-    /**
-     * KeepAliveRetryTransportWrapper constructor.
-     *
-     * @param TransportInterface $transport
-     */
-    public function __construct(TransportInterface $transport, int $maxRetries)
+    public function __construct(HttpTransport $transport)
     {
-        $this->transport = $transport;
-        $this->maxRetries = $maxRetries;
-
-    }
-
-    /**
-     * @return TransportInterface
-     */
-    public function getTransport()
-    {
-        return $this->transport;
-    }
-
-    /**
-     * Sends a Message over this transport.
-     *
-     * @param Message $message
-     *
-     * @return int calls function to send message
-     */
-    public function send(Message $message)
-    {
-        $this->incrementedRetries++;
-        try {
-            return $this->transport->send($message);
-        } catch (\RuntimeException $e) {
-            if ($e->getMessage() !== self::NO_RESPONSE) {
-                throw $e;
-            }
-            if($this->incrementedRetries === $this->maxRetries){
-                return $this->transport->send($message);
-            }
-            return $this->send($message);
-        }
+        parent::__construct($transport, 1, function (RuntimeException $e) {
+            return $e->getMessage() === self::NO_RESPONSE;
+        });
     }
 }

--- a/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
+++ b/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
@@ -11,6 +11,9 @@ class KeepAliveRetryTransportWrapper extends RetryTransportWrapper
      */
     const NO_RESPONSE = "Graylog-Server didn't answer properly, expected 'HTTP/1.x 202 Accepted', response is ''";
 
+    /**
+     * @param HttpTransport $transport
+     */
     public function __construct(HttpTransport $transport)
     {
         parent::__construct($transport, 1, function (RuntimeException $e) {

--- a/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
+++ b/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Gelf\Transport;
+
+use Gelf\MessageInterface as Message;
+
+class KeepAliveRetryTransportWrapper extends AbstractTransport
+{
+    /**
+     * @const string
+     */
+    const NO_RESPONSE = "Graylog-Server didn't answer properly, expected 'HTTP/1.x 202 Accepted', response is ''";
+
+    /**
+     * @var HttpTransport
+     */
+    protected $transport;
+
+    /**
+     * KeepAliveRetryTransportWrapper constructor.
+     *
+     * @param HttpTransport $transport
+     */
+    public function __construct(HttpTransport $transport)
+    {
+        $this->transport = $transport;
+    }
+
+    /**
+     * @return HttpTransport
+     */
+    public function getTransport()
+    {
+        return $this->transport;
+    }
+
+    /**
+     * Sends a Message over this transport.
+     *
+     * @param Message $message
+     *
+     * @return int calls function to send message
+     */
+    public function send(Message $message)
+    {
+        try {
+            return $this->transport->send($message);
+        } catch (\RuntimeException $e) {
+            if ($e->getMessage() !== self::NO_RESPONSE) {
+                throw $e;
+            }
+            return $this->transport->send($message);
+        }
+    }
+}

--- a/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
+++ b/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
@@ -19,15 +19,15 @@ class KeepAliveRetryTransportWrapper extends AbstractTransport
     /**
      * KeepAliveRetryTransportWrapper constructor.
      *
-     * @param HttpTransport $transport
+     * @param TransportInterface $transport
      */
-    public function __construct(HttpTransport $transport)
+    public function __construct(TransportInterface $transport)
     {
         $this->transport = $transport;
     }
 
     /**
-     * @return HttpTransport
+     * @return TransportInterface
      */
     public function getTransport()
     {

--- a/src/Gelf/Transport/RetryTransportWrapper.php
+++ b/src/Gelf/Transport/RetryTransportWrapper.php
@@ -64,7 +64,7 @@ class RetryTransportWrapper extends AbstractTransport
             try {
                 $tries++;
                 return $this->transport->send($message);
-            } catch (\Throwable $e) {
+            } catch (\Exception $e) {
                 if ($this->maxRetries !== 0 && $tries > $this->maxRetries) {
                     throw $e;
                 }

--- a/src/Gelf/Transport/RetryTransportWrapper.php
+++ b/src/Gelf/Transport/RetryTransportWrapper.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Gelf\Transport;
+
+use Gelf\MessageInterface as Message;
+use RuntimeException;
+
+class RetryTransportWrapper extends AbstractTransport
+{
+    /**
+     * @const string
+     */
+    const NO_RESPONSE = "Graylog-Server didn't answer properly, expected 'HTTP/1.x 202 Accepted', response is ''";
+
+    /**
+     * @var HttpTransport
+     */
+    protected $transport;
+
+    /**
+     * @var int
+     */
+    protected $maxRetries;
+
+    /**
+     * @var callable|null
+     */
+    protected $exceptionMatcher;
+
+    /**
+     * KeepAliveRetryTransportWrapper constructor.
+     *
+     * @param TransportInterface $transport
+     * @param int $maxRetries
+     * @param callable|null $exceptionMatcher
+     */
+    public function __construct(TransportInterface $transport, $maxRetries, $exceptionMatcher = null)
+    {
+        $this->transport = $transport;
+        $this->maxRetries = $maxRetries;
+        $this->exceptionMatcher = $exceptionMatcher;
+    }
+
+    /**
+     * @return TransportInterface
+     */
+    public function getTransport()
+    {
+        return $this->transport;
+    }
+
+    /**
+     * Sends a Message over this transport.
+     *
+     * @param Message $message
+     *
+     * @return int calls function to send message
+     */
+    public function send(Message $message)
+    {
+        $tries = 0;
+
+        while (true) {
+            try {
+                $tries++;
+                return $this->transport->send($message);
+            } catch (RuntimeException $e) {
+                if ($this->maxRetries !== 0 && $tries > $this->maxRetries) {
+                    throw $e;
+                }
+
+                if ($this->exceptionMatcher && !call_user_func($this->exceptionMatcher, $e)) {
+                    throw $e;
+                }
+            }
+        }
+    }
+}

--- a/src/Gelf/Transport/RetryTransportWrapper.php
+++ b/src/Gelf/Transport/RetryTransportWrapper.php
@@ -32,7 +32,7 @@ class RetryTransportWrapper extends AbstractTransport
      *
      * @param TransportInterface $transport
      * @param int $maxRetries
-     * @param callable|null $exceptionMatcher
+     * @param callable(\Throwable):bool $exceptionMatcher
      */
     public function __construct(TransportInterface $transport, $maxRetries, $exceptionMatcher = null)
     {
@@ -64,7 +64,7 @@ class RetryTransportWrapper extends AbstractTransport
             try {
                 $tries++;
                 return $this->transport->send($message);
-            } catch (RuntimeException $e) {
+            } catch (\Throwable $e) {
                 if ($this->maxRetries !== 0 && $tries > $this->maxRetries) {
                     throw $e;
                 }

--- a/src/Gelf/Transport/RetryTransportWrapper.php
+++ b/src/Gelf/Transport/RetryTransportWrapper.php
@@ -13,7 +13,7 @@ class RetryTransportWrapper extends AbstractTransport
     const NO_RESPONSE = "Graylog-Server didn't answer properly, expected 'HTTP/1.x 202 Accepted', response is ''";
 
     /**
-     * @var HttpTransport
+     * @var TransportInterface
      */
     protected $transport;
 

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -10,7 +10,7 @@ use \PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RuntimeException;
 
 /**
- * @covers KeepAliveRetryTransportWrapper
+ * @covers \Gelf\Transport\KeepAliveRetryTransportWrapper
  */
 class KeepAliveRetryTransportWrapperTest extends TestCase
 {

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -4,7 +4,9 @@ namespace Gelf\Test\Transport;
 
 use Gelf\Message;
 use Gelf\TestCase;
+use Gelf\Transport\HttpTransport;
 use Gelf\Transport\KeepAliveRetryTransportWrapper;
+use Gelf\Transport\RetryTransportWrapper;
 use Gelf\Transport\TransportInterface;
 use \PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RuntimeException;
@@ -25,7 +27,7 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     private $message;
 
     /**
-     * @var TransportInterface|MockObject
+     * @var HttpTransport|MockObject
      */
     private $transport;
 
@@ -43,9 +45,8 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     {
         $this->message = new Message();
         $this->transport = $this->buildTransport();
-        $this->wrapper   = new KeepAliveRetryTransportWrapper($this->transport, 1);
-        $this->wrapperRetries   = new KeepAliveRetryTransportWrapper($this->transport, 3);
-
+        $this->wrapper   = new KeepAliveRetryTransportWrapper($this->transport);
+//        $this->wrapperRetries   = new RetryTransportWrapper($this->transport, 3);
     }
 
     public function testSendSuccess()
@@ -99,30 +100,6 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage response is ''
-     */
-    public function testSendWithThreeRetries()
-    {
-        $expectedException1 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
-        $expectedException2 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
-        $expectedException3 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
-        $expectedException4 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
-
-        $this->transport->expects($this->exactly(4))
-            ->method('send')
-            ->with($this->message)
-            ->will($this->onConsecutiveCalls(
-                $this->throwException($expectedException1),
-                $this->throwException($expectedException2),
-                $this->throwException($expectedException3),
-                $this->throwException($expectedException4)
-            ));
-
-        $this->wrapperRetries->send($this->message);
-    }
-
-    /**
-     * @expectedException RuntimeException
      * @expectedExceptionMessage foo
      */
     public function testSendFailWithUnmanagedException()
@@ -138,10 +115,10 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     }
 
     /**
-     * @return MockObject|TransportInterface
+     * @return MockObject|HttpTransport
      */
     private function buildTransport()
     {
-        return $this->getMock("\\Gelf\\Transport\\HttpTransport");
+        return $this->createMock("\\Gelf\\Transport\\HttpTransport");
     }
 }

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Gelf\Test\Transport;
+
+use Gelf\Message;
+use Gelf\TestCase;
+use Gelf\Transport\AbstractTransport;
+use Gelf\Transport\KeepAliveRetryTransportWrapper;
+use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use RuntimeException;
+
+/**
+ * @covers KeepAliveRetryTransportWrapper
+ */
+class KeepAliveRetryTransportWrapperTest extends TestCase
+{
+    /**
+     * @const string
+     */
+    const SUCCESS_VALUE = "HTTP/1.1 202 Accepted\r\n\r\n";
+
+    /**
+     * @var Message
+     */
+    private $message;
+
+    /**
+     * @var AbstractTransport|MockObject
+     */
+    private $transport;
+
+    /**
+     * @var KeepAliveRetryTransportWrapper
+     */
+    private $wrapper;
+
+    public function setUp()
+    {
+        $this->message = new Message();
+        $this->transport = $this->buildTransport();
+        $this->wrapper   = new KeepAliveRetryTransportWrapper($this->transport);
+    }
+
+    public function testSendSuccess()
+    {
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with($this->message)
+            ->will($this->returnValue(self::SUCCESS_VALUE));
+
+        $bytes = $this->wrapper->send($this->message);
+
+        $this->assertEquals(self::SUCCESS_VALUE, $bytes);
+    }
+
+    public function testSendSuccessAfterRetry()
+    {
+        $expectedException = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
+
+        $this->transport->expects($this->exactly(2))
+            ->method('send')
+            ->with($this->message)
+            ->will($this->onConsecutiveCalls(
+                $this->throwException($expectedException),
+                $this->returnValue(self::SUCCESS_VALUE)
+            ));
+
+        $bytes = $this->wrapper->send($this->message);
+
+        $this->assertEquals(self::SUCCESS_VALUE, $bytes);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage response is ''
+     */
+    public function testSendFailTwiceWithoutResponse()
+    {
+        $expectedException1 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
+        $expectedException2 = new RuntimeException(KeepAliveRetryTransportWrapper::NO_RESPONSE);
+
+        $this->transport->expects($this->exactly(2))
+            ->method('send')
+            ->with($this->message)
+            ->will($this->onConsecutiveCalls(
+                $this->throwException($expectedException1),
+                $this->throwException($expectedException2)
+            ));
+
+        $this->wrapper->send($this->message);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage foo
+     */
+    public function testSendFailWithUnmanagedException()
+    {
+        $expectedException = new RuntimeException('foo');
+
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with($this->message)
+            ->willThrowException($expectedException);
+
+        $this->wrapper->send($this->message);
+    }
+
+    /**
+     * @return MockObject|AbstractTransport
+     */
+    private function buildTransport()
+    {
+        return $this->getMockForAbstractClass("\\Gelf\\Transport\\AbstractTransport");
+    }
+}

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -4,8 +4,8 @@ namespace Gelf\Test\Transport;
 
 use Gelf\Message;
 use Gelf\TestCase;
-use Gelf\Transport\HttpTransport;
 use Gelf\Transport\KeepAliveRetryTransportWrapper;
+use Gelf\Transport\TransportInterface;
 use \PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RuntimeException;
 
@@ -25,7 +25,7 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     private $message;
 
     /**
-     * @var HttpTransport|MockObject
+     * @var TransportInterface|MockObject
      */
     private $transport;
 
@@ -107,7 +107,7 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     }
 
     /**
-     * @return MockObject|HttpTransport
+     * @return MockObject|TransportInterface
      */
     private function buildTransport()
     {

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -6,9 +6,7 @@ use Gelf\Message;
 use Gelf\TestCase;
 use Gelf\Transport\HttpTransport;
 use Gelf\Transport\KeepAliveRetryTransportWrapper;
-use Gelf\Transport\RetryTransportWrapper;
-use Gelf\Transport\TransportInterface;
-use \PHPUnit_Framework_MockObject_MockObject as MockObject;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RuntimeException;
 
 /**
@@ -36,17 +34,11 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
      */
     private $wrapper;
 
-    /**
-     * @var KeepAliveRetryTransportWrapper
-     */
-    private $wrapperRetries;
-
     public function setUp()
     {
         $this->message = new Message();
         $this->transport = $this->buildTransport();
         $this->wrapper   = new KeepAliveRetryTransportWrapper($this->transport);
-//        $this->wrapperRetries   = new RetryTransportWrapper($this->transport, 3);
     }
 
     public function testSendSuccess()

--- a/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/KeepAliveRetryTransportWrapperTest.php
@@ -4,7 +4,7 @@ namespace Gelf\Test\Transport;
 
 use Gelf\Message;
 use Gelf\TestCase;
-use Gelf\Transport\AbstractTransport;
+use Gelf\Transport\HttpTransport;
 use Gelf\Transport\KeepAliveRetryTransportWrapper;
 use \PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RuntimeException;
@@ -25,7 +25,7 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     private $message;
 
     /**
-     * @var AbstractTransport|MockObject
+     * @var HttpTransport|MockObject
      */
     private $transport;
 
@@ -107,10 +107,10 @@ class KeepAliveRetryTransportWrapperTest extends TestCase
     }
 
     /**
-     * @return MockObject|AbstractTransport
+     * @return MockObject|HttpTransport
      */
     private function buildTransport()
     {
-        return $this->getMockForAbstractClass("\\Gelf\\Transport\\AbstractTransport");
+        return $this->getMock("\\Gelf\\Transport\\HttpTransport");
     }
 }

--- a/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
@@ -27,6 +27,12 @@ class RetryTransportWrapperTest extends TestCase
         $this->transport = $this->buildTransport();
     }
 
+    public function testGetTransport()
+    {
+        $wrapper = new RetryTransportWrapper($this->transport, 1, null);
+        $this->assertEquals($this->transport, $wrapper->getTransport());
+    }
+
     /**
      * @expectedException RuntimeException
      * @expectedExceptionMessage bar

--- a/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
@@ -29,7 +29,7 @@ class RetryTransportWrapperTest extends TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage response is ''
+     * @expectedExceptionMessage bar
      */
     public function testWithoutMatcher()
     {
@@ -53,7 +53,7 @@ class RetryTransportWrapperTest extends TestCase
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage response is ''
+     * @expectedExceptionMessage bar
      */
     public function testWithMatcher()
     {
@@ -79,7 +79,7 @@ class RetryTransportWrapperTest extends TestCase
     
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage response is ''
+     * @expectedExceptionMessage foo
      */
     public function testWithFalseMatcher()
     {

--- a/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
+++ b/tests/Gelf/Test/Transport/RetryTransportWrapperTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Gelf\Test\Transport;
+
+use Gelf\Message;
+use Gelf\TestCase;
+use Gelf\Transport\AbstractTransport;
+use Gelf\Transport\RetryTransportWrapper;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+
+class RetryTransportWrapperTest extends TestCase
+{
+    /**
+     * @var Message
+     */
+    private $message;
+
+    /**
+     * @var AbstractTransport|MockObject
+     */
+    private $transport;
+
+    public function setUp()
+    {
+        $this->message = new Message();
+        $this->transport = $this->buildTransport();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage response is ''
+     */
+    public function testWithoutMatcher()
+    {
+        $wrapper = new RetryTransportWrapper($this->transport, 1, null);
+
+        $expectedException1 = new RuntimeException('foo');
+        $expectedException2 = new RuntimeException('bar');
+
+        $this->transport->expects($this->exactly(2))
+            ->method('send')
+            ->with($this->message)
+            ->will($this->onConsecutiveCalls(
+                $this->throwException($expectedException1),
+                $this->throwException($expectedException2)
+            ));
+
+        $bytes = $wrapper->send($this->message);
+
+        $this->assertEquals('', $bytes);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage response is ''
+     */
+    public function testWithMatcher()
+    {
+        $wrapper = new RetryTransportWrapper($this->transport, 1, function (RuntimeException $e) {
+            return true;
+        });
+
+        $expectedException1 = new RuntimeException('foo');
+        $expectedException2 = new RuntimeException('bar');
+
+        $this->transport->expects($this->exactly(2))
+            ->method('send')
+            ->with($this->message)
+            ->will($this->onConsecutiveCalls(
+                $this->throwException($expectedException1),
+                $this->throwException($expectedException2)
+            ));
+
+        $bytes = $wrapper->send($this->message);
+
+        $this->assertEquals('', $bytes);
+    }
+    
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage response is ''
+     */
+    public function testWithFalseMatcher()
+    {
+        $wrapper = new RetryTransportWrapper($this->transport, 1, function (RuntimeException $e) {
+            return false;
+        });
+
+        $expectedException1 = new RuntimeException('foo');
+
+        $this->transport->expects($this->once())
+            ->method('send')
+            ->with($this->message)
+            ->willThrowException($expectedException1);
+
+        $bytes = $wrapper->send($this->message);
+
+        $this->assertEquals('', $bytes);
+    }
+
+    /**
+     * @return MockObject|AbstractTransport
+     */
+    private function buildTransport()
+    {
+        return $this->createMock("\\Gelf\\Transport\\AbstractTransport");
+    }
+}


### PR DESCRIPTION
When using a Keep-Alive connection, the connection can be closed at any time by the server. Thus, this PR add a retry wrapper (class `KeepAliveRetryTransportWrapper`) that could be used to retry the request when no response is received from the server.

See #127 for all details.