### PR TITLE
Allow psr/log 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "psr/log": "~1.0",
+        "psr/log": "^1.0|^2.0",
         "paragonie/constant_time_encoding": "^1|^2"
     },
     "autoload": {


### PR DESCRIPTION
`psr/log` 2.0 was tagged a couple of weeks ago: https://twitter.com/phpfig/status/1415413578191024130

3.0 has been tagged too, but it would require a version bump and dropping support for `psr/log` 1.0, so we'll need to wait for now.

Details are available in the new meta document: https://www.php-fig.org/psr/psr-3/meta/
As always, changes are done in two steps to make a smoother transition path, as per the [PHP-FIG evolution bylaw](https://www.php-fig.org/bylaws/psr-evolution/)

This PR is a blocker for https://github.com/Seldaek/monolog/pull/1564