### PR TITLE
Add support for verify_peer_name

### DIFF
--- a/src/Gelf/Transport/SslOptions.php
+++ b/src/Gelf/Transport/SslOptions.php
@@ -30,6 +30,11 @@ class SslOptions
     private bool $allowSelfSigned = false;
 
     /**
+     * Require verification of peer name.
+     */
+    private bool $verifyPeerName = true;
+
+    /**
      * Path to custom CA
      */
     private ?string $caFile = null;
@@ -108,12 +113,29 @@ class SslOptions
     }
 
     /**
+     * Whether to check the peer name
+     */
+    public function getVerifyPeerName(): bool
+    {
+        return $this->verifyPeerName;
+    }
+
+    /**
+     * Enable or disable the peer name check
+     */
+    public function setVerifyPeerName(bool $verifyPeerName): void
+    {
+        $this->verifyPeerName = $verifyPeerName;
+    }
+
+    /**
      * Returns a stream-context representation of this config
      */
     public function toStreamContext(?string $serverName = null): array
     {
         $sslContext = [
             'verify_peer'       => $this->verifyPeer,
+            'verify_peer_name'  => $this->verifyPeerName,
             'allow_self_signed' => $this->allowSelfSigned
         ];
 

--- a/tests/Gelf/Test/Transport/SslOptionsTest.php
+++ b/tests/Gelf/Test/Transport/SslOptionsTest.php
@@ -23,17 +23,20 @@ class SslOptionsTest extends TestCase
 
         // test sane defaults
         self::assertTrue($options->getVerifyPeer());
+        self::assertTrue($options->getVerifyPeerName());
         self::assertFalse($options->getAllowSelfSigned());
         self::assertNull($options->getCaFile());
         self::assertNull($options->getCiphers());
 
         // test setters
         $options->setVerifyPeer(false);
+        $options->setVerifyPeerName(false);
         $options->setAllowSelfSigned(true);
         $options->setCaFile('/path/to/ca');
         $options->setCiphers('ALL:!ADH:@STRENGTH');
 
         self::assertFalse($options->getVerifyPeer());
+        self::assertFalse($options->getVerifyPeerName());
         self::assertTrue($options->getAllowSelfSigned());
         self::assertEquals('/path/to/ca', $options->getCaFile());
         self::assertEquals('ALL:!ADH:@STRENGTH', $options->getCiphers());
@@ -46,11 +49,13 @@ class SslOptionsTest extends TestCase
         self::assertEquals([
             'ssl' => [
                 'verify_peer' => true,
+                'verify_peer_name' => true,
                 'allow_self_signed' => false,
             ]
         ], $options->toStreamContext());
 
         $options->setVerifyPeer(false);
+        $options->setVerifyPeerName(false);
         $options->setAllowSelfSigned(true);
         $options->setCaFile('/path/to/ca');
         $options->setCiphers('ALL:!ADH:@STRENGTH');
@@ -58,6 +63,7 @@ class SslOptionsTest extends TestCase
         self::assertEquals([
             'ssl' => [
                 'verify_peer' => false,
+                'verify_peer_name' => false,
                 'allow_self_signed' => true,
                 'cafile' => '/path/to/ca',
                 'ciphers' => 'ALL:!ADH:@STRENGTH'
@@ -70,6 +76,7 @@ class SslOptionsTest extends TestCase
         self::assertEquals([
             'ssl' => [
                 'verify_peer' => false,
+                'verify_peer_name' => false,
                 'allow_self_signed' => true,
             ]
         ], $options->toStreamContext());


### PR DESCRIPTION
I found this option was required for a recent project I was working on.

See https://www.php.net/manual/en/context.ssl.php#context.ssl.verify-peer for PHP documentation.