### PR TITLE
Provide `psr/log-implementation`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,8 @@
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
         "vimeo/psalm": "^4.22"
+    },
+    "provide": {
+        "psr/log-implementation": "3.0.0"
     }
 }


### PR DESCRIPTION
Hello! 👋 I noticed that, at present, the library doesn't expressly identify itself as being a PSR-3 compatible provider (`psr/log-implementation`.) This *can* [apparently be inferred](https://packagist.org/providers/psr/log-implementation) by the `psr/log` requirement, but I'm not certain how reliably that works for downstream packages that require the implementation form.

Not sure if adding this interests you, but thought I'd throw it out there. Cheers! 👍 