### PR TITLE
chore: improve ci, add php 8.2 tests, allow phpunit 10, add psalm baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,11 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.2
           - 8.1
           - 8.0
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
@@ -28,10 +29,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.1
-          - 8.0
+          - 8.2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 /composer.lock
 .phpunit.result.cache
+/.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^4.22"
+        "phpunit/phpunit": "^9.6|^10.1",
+        "squizlabs/php_codesniffer": "^3.7",
+        "vimeo/psalm": "^5.11"
     },
     "provide": {
         "psr/log-implementation": "3.0.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="./tests/bootstrap.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         cacheDirectory=".phpunit.cache">
+  <coverage/>
 
-<phpunit bootstrap="./tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="gelf php test suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
 
-    <testsuites>
-        <testsuite name="gelf php test suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
+  <source>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./tests</directory>
+      <directory>./vendor</directory>
+      <directory>./examples</directory>
+    </exclude>
+  </source>
 
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./tests</directory>
-                <directory>./vendor</directory>
-                <directory>./examples</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <psalm
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="https://getpsalm.org/schema/config"
+        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
I think psalm need only to run one time, not in a matrix. Or is there a specific reason to run it on different php versions?