### PR TITLE
chore: migrate psalm v4 => v5, fix 2 psalm errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.6",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^5.11"
     },
     "provide": {
         "psr/log-implementation": "3.0.0"

--- a/src/Gelf/Transport/UdpTransport.php
+++ b/src/Gelf/Transport/UdpTransport.php
@@ -93,11 +93,11 @@ class UdpTransport extends AbstractTransport
      */
     private function sendMessageInChunks(string $rawMessage): int
     {
+        /** @var int<1, max> $length */
+        $length = $this->chunkSize - self::CHUNK_HEADER_LENGTH;
+
         // split to chunks
-        $chunks = str_split($rawMessage, $this->chunkSize - self::CHUNK_HEADER_LENGTH);
-        if ($chunks === false) {
-            throw new LogicException('Invalid chunk-size. Cannot chunk');
-        }
+        $chunks = str_split($rawMessage, $length);
 
         $numChunks = count($chunks);
 


### PR DESCRIPTION
After i did a look in the history of the file, i just noticed that the LogicException was just added for psalm in the first place.