### PR TITLE
Fix #151 make gelf php compatible with psr log 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   PHPUnit:
-    name: PHPUnit (PHP ${{ matrix.php }})
+    name: PHPUnit (PHP ${{ matrix.php }} ${{ matrix.dependencies }})
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -14,13 +14,21 @@ jobs:
           - 8.2
           - 8.1
           - 8.0
+        dependencies:
+          - highest
+          - lowest
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-      - run: composer update --dev
+      - name: "Install lowest dependencies"
+        if: ${{ matrix.dependencies == 'lowest' }}
+        run: "composer update --prefer-lowest --no-interaction --no-progress"
+      - name: "Install highest dependencies"
+        if: ${{ matrix.dependencies == 'highest' }}
+        run: "composer update --no-interaction --no-progress"
       - run: vendor/bin/phpunit --coverage-text
 
   Psalm:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
          bootstrap="./tests/bootstrap.php"
          colors="true"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         cacheDirectory=".phpunit.cache">
+>
     <coverage/>
 
     <testsuites>

--- a/src/Gelf/Logger.php
+++ b/src/Gelf/Logger.php
@@ -40,7 +40,7 @@ class Logger extends AbstractLogger implements LoggerInterface
     }
 
     /** @inheritDoc */
-    public function log($level, string|Stringable $message, array $context = []): void
+    public function log($level, $message, array $context = []): void
     {
         $messageObj = $this->initMessage($level, $message, $context);
 


### PR DESCRIPTION
Fixes #151

This patch is targeting `master`, but is aimed at `2.0.1` (to be released as a patch).

Also very happy to send a follow-up after a `2.0.1` release, to drop `psr/log:^1` support, and re-introduce the type declarations :-) 