### PR TITLE
mark monolog/monolog:^1 as conflicted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,9 @@
         "squizlabs/php_codesniffer": "^3.6",
         "vimeo/psalm": "^5.11"
     },
+    "conflict": {
+        "monolog/monolog": "^1"
+    },
     "provide": {
         "psr/log-implementation": "3.0.0"
     }


### PR DESCRIPTION
solves https://github.com/bzikarsky/gelf-php/issues/144

monolog in version 1 calls removed methods in gelf: https://github.com/Seldaek/monolog/blob/1.x/src/Monolog/Formatter/GelfMessageFormatter.php#L98