### PR TITLE
Option to close socket connection on write

### DIFF
--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -39,7 +39,8 @@ class TcpTransport extends AbstractTransport
     public function __construct(
         private string $host = self::DEFAULT_HOST,
         private int $port = self::DEFAULT_PORT,
-        private ?SslOptions $sslOptions = null
+        private ?SslOptions $sslOptions = null,
+        private bool $closeOnWrite = false,
     ) {
         parent::__construct();
 
@@ -63,7 +64,13 @@ class TcpTransport extends AbstractTransport
         $rawMessage = $this->getMessageEncoder()->encode($message) . "\0";
 
         // send message in one packet
-        return $this->socketClient->write($rawMessage);
+        $result = $this->socketClient->write($rawMessage);
+
+        if ($this->closeOnWrite) {
+            $this->socketClient->close();
+        }
+
+        return $result;
     }
 
     private function getScheme(): string


### PR DESCRIPTION
If U have long running console app socket connection will become idle and you'll get 
Failed to write to socket: fwrite(): Send of 2897 bytes failed with errno=32 Broken pipe (8)
closing connection after writing message solves this issue.