### PR TITLE
Remove none existing null handling in UdpTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Add gelf-php to `composer.json` either by running `composer require graylog2/gel
 
     "require": {
        // ...
-       "graylog2/gelf-php": "~1.5"
+       "graylog2/gelf-php": "^2.0"
        // ...
     }
 

--- a/src/Gelf/Transport/HttpTransport.php
+++ b/src/Gelf/Transport/HttpTransport.php
@@ -46,7 +46,7 @@ class HttpTransport extends AbstractTransport
     ) {
         parent::__construct();
 
-        if ($port == self::AUTO_SSL_PORT && $sslOptions === null) {
+        if ($port === self::AUTO_SSL_PORT && $sslOptions === null) {
             $this->sslOptions = new SslOptions();
         }
 
@@ -72,7 +72,7 @@ class HttpTransport extends AbstractTransport
         $parsed = parse_url($url);
         
         // check it's a valid URL
-        if (false === $parsed || !isset($parsed['host']) || !isset($parsed['scheme'])) {
+        if (false === $parsed || !isset($parsed['host'], $parsed['scheme'])) {
             throw new \InvalidArgumentException("$url is not a valid URL");
         }
         
@@ -86,7 +86,7 @@ class HttpTransport extends AbstractTransport
         $defaults = ['port' => 80, 'path' => '', 'user' => null, 'pass' => ''];
 
         // change some defaults for https
-        if ($scheme == 'https') {
+        if ($scheme === 'https') {
             $sslOptions = $sslOptions ?: new SslOptions();
             $defaults['port'] = 443;
         }

--- a/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
+++ b/src/Gelf/Transport/KeepAliveRetryTransportWrapper.php
@@ -13,7 +13,7 @@ class KeepAliveRetryTransportWrapper extends RetryTransportWrapper
 
     public function __construct(HttpTransport $transport)
     {
-        parent::__construct($transport, 1, function (Throwable $e) {
+        parent::__construct($transport, 1, static function (Throwable $e) {
             return $e instanceof RuntimeException && $e->getMessage() === self::NO_RESPONSE;
         });
     }

--- a/src/Gelf/Transport/RetryTransportWrapper.php
+++ b/src/Gelf/Transport/RetryTransportWrapper.php
@@ -21,7 +21,7 @@ class RetryTransportWrapper implements TransportInterface
         private int $maxRetries,
         ?callable $exceptionMatcher = null
     ) {
-        $this->exceptionMatcher = Closure::fromCallable($exceptionMatcher ?? fn (Throwable $_) => true);
+        $this->exceptionMatcher = Closure::fromCallable($exceptionMatcher ?? static fn (Throwable $_) => true);
     }
 
     public function getTransport(): TransportInterface

--- a/src/Gelf/Transport/StreamSocketClient.php
+++ b/src/Gelf/Transport/StreamSocketClient.php
@@ -124,7 +124,7 @@ class StreamSocketClient
             $failed = false;
             $errorMessage = "Failed to write to socket";
             /** @psalm-suppress InvalidArgument */
-            set_error_handler(function ($errno, $errstr) use (&$failed, &$errorMessage) {
+            set_error_handler(static function (int $errno, string $errstr) use (&$failed, &$errorMessage) {
                 $failed = true;
                 $errorMessage .= ": $errstr ($errno)";
             });

--- a/src/Gelf/Transport/TcpTransport.php
+++ b/src/Gelf/Transport/TcpTransport.php
@@ -43,7 +43,7 @@ class TcpTransport extends AbstractTransport
     ) {
         parent::__construct();
 
-        if ($port == self::AUTO_SSL_PORT && $this->sslOptions == null) {
+        if ($port === self::AUTO_SSL_PORT && $this->sslOptions === null) {
             $this->sslOptions = new SslOptions();
         }
 

--- a/src/Gelf/Transport/UdpTransport.php
+++ b/src/Gelf/Transport/UdpTransport.php
@@ -44,8 +44,8 @@ class UdpTransport extends AbstractTransport
     /**
      * Class constructor
      *
-     * @param string $host when NULL or empty DEFAULT_HOST is used
-     * @param int $port when NULL or empty DEFAULT_PORT is used
+     * @param string $host when empty DEFAULT_HOST is used
+     * @param int $port when empty DEFAULT_PORT is used
      * @param int $chunkSize defaults to CHUNK_SIZE_WAN,
      *                          0 disables chunks completely
      */
@@ -56,7 +56,7 @@ class UdpTransport extends AbstractTransport
     ) {
         parent::__construct();
 
-        // allow NULL-like values for fallback on default
+        // fallback to default on empty values
         $host = $host ?: self::DEFAULT_HOST;
         $port = $port ?: self::DEFAULT_PORT;
 


### PR DESCRIPTION
After upgrading from version 1.6.4 to 2.0.1 we got a crash because of a passed null host value to the `UdpTransport` class in a pipeline, which was an unexpected break but obviously not unknown when types are introduced.

When looking at the class I noticed the null comments and checks were still in place which this PR intends to fix. I realized the two checks should stay because they are still checking for empty strings.

The MR ended up being very minor but fixing some more none strict checks which are safe because the type is given. Feel free to merge or (partly) take into any other commit.
