### PR TITLE
Pass context array key as string at validate0101()

### DIFF
--- a/src/Gelf/MessageValidator.php
+++ b/src/Gelf/MessageValidator.php
@@ -82,7 +82,7 @@ class MessageValidator implements MessageValidatorInterface
         }
 
         foreach ($message->getAllAdditionals() as $key => $value) {
-            if (!preg_match('#^[\w\.\-]*$#', $key)) {
+            if (!preg_match('#^[\w\.\-]*$#', (string)$key)) {
                 $reason = sprintf(
                     "additional key '%s' contains invalid characters",
                     $key


### PR DESCRIPTION
MessageValidator fails when we use an array with keys as integers as the context. Let's look at the example:

```php
$files[] = 'file_0.php';
$files[] = 'file_1.php';

Log::info("Files", $files);
```

then, `preg_match()` complains it needs the second argument to be a string at `validate0101()` in `MessageValidator`