### PR TITLE
Fix implicitly nullable parameter declarations for PHP 8.4

### DIFF
--- a/src/Gelf/Logger.php
+++ b/src/Gelf/Logger.php
@@ -31,7 +31,7 @@ class Logger extends AbstractLogger implements LoggerInterface
      * Creates a PSR-3 Logger for GELF/Graylog2
      */
     public function __construct(
-        PublisherInterface $publisher = null,
+        ?PublisherInterface $publisher = null,
         private array $defaultContext = []
     ) {
         // if no publisher is provided build a "default" publisher

--- a/src/Gelf/MessageValidatorInterface.php
+++ b/src/Gelf/MessageValidatorInterface.php
@@ -22,5 +22,5 @@ interface MessageValidatorInterface
     /**
      * Validate a given message for validity.
      */
-    public function validate(MessageInterface $message, string &$reason = null): bool;
+    public function validate(MessageInterface $message, ?string &$reason = null): bool;
 }


### PR DESCRIPTION
Ensure method parameter types are nullable where needed to avoid a deprecation notice. Adjustments made in MessageValidatorInterface and Logger constructors.