### PR TITLE
add setConnectTimeout on UdpTransport

### DIFF
--- a/src/Gelf/Transport/UdpTransport.php
+++ b/src/Gelf/Transport/UdpTransport.php
@@ -89,6 +89,21 @@ class UdpTransport extends AbstractTransport
     }
 
     /**
+     * @deprecated use setConnectTimeoutInMs instead
+     * @see TcpTransport::setConnectTimeout
+     */
+    public function setConnectTimeout(int $timeout): void
+    {
+        $this->socketClient->setConnectTimeout($timeout);
+    }
+    
+    public function setConnectTimeoutInMs(int $timeoutInMs): void
+    {
+        // currently socketClient only supports int
+        $this->socketClient->setConnectTimeout((int)ceil($timeoutInMs / 1_000));
+    }
+
+    /**
      * Sends given string in multiple chunks
      */
     private function sendMessageInChunks(string $rawMessage): int


### PR DESCRIPTION
may also relate to issue #54

adds a setConnectTimeout function to UdpTransport that has same signature as TcpTransport for compatibility.
Also add setConnectTimeoutInMs function to UdpTransport to have a cleaner, future-proof version.