### PR TITLE
test: refactor StreamSocketClient tests into focused test cases

### DIFF
--- a/src/Gelf/Logger.php
+++ b/src/Gelf/Logger.php
@@ -39,7 +39,10 @@ class Logger extends AbstractLogger implements LoggerInterface
         $this->publisher = $publisher ?? new Publisher(new UdpTransport());
     }
 
-    /** @inheritDoc */
+    /**
+     * @param mixed $level
+     * @param string|\Stringable $message
+     */
     public function log($level, $message, array $context = []): void
     {
         $messageObj = $this->initMessage($level, $message, $context);

--- a/src/Gelf/Message.php
+++ b/src/Gelf/Message.php
@@ -244,9 +244,10 @@ class Message implements MessageInterface
         }
 
         // return after filtering empty strings and null values
-        return array_filter($message, function ($message) {
+        return array_filter($message, function (mixed $message): bool {
+            /** @psalm-suppress RiskyTruthyFalsyComparison */
             return is_bool($message)
-                || (is_string($message) && strlen($message))
+                || (is_string($message) && strlen($message) > 0)
                 || is_int($message)
                 || !empty($message);
         });

--- a/src/Gelf/Transport/HttpTransport.php
+++ b/src/Gelf/Transport/HttpTransport.php
@@ -96,7 +96,7 @@ class HttpTransport extends AbstractTransport
         $transport = new self($parsed['host'], $parsed['port'], $parsed['path'], $sslOptions);
 
         // add optional authentication
-        if ($parsed['user']) {
+        if (null !== $parsed['user'] && '' !== $parsed['user']) {
             $transport->setAuthentication($parsed['user'], $parsed['pass']);
         }
 

--- a/tests/Gelf/Test/Transport/StreamSocketClientSslTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientSslTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the php-gelf package.
+ *
+ * (c) Benjamin Zikarsky <http://benjamin-zikarsky.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gelf\Test\Transport;
+
+use Gelf\Transport\SslOptions;
+use Gelf\Transport\StreamSocketClient;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StreamSocketClientSslTest extends TestCase
+{
+    public function testSslConnectionToPlainServerFails(): void
+    {
+        self::expectException(RuntimeException::class);
+
+        $server = stream_socket_server("tcp://127.0.0.1:0");
+        $socketName = stream_socket_get_name($server, remote: false);
+        [, $port] = explode(":", $socketName);
+
+        try {
+            $client = new StreamSocketClient('ssl', '127.0.0.1', (int)$port);
+            $client->getSocket();
+        } finally {
+            fclose($server);
+        }
+    }
+
+    public function testSslContextIsPreserved(): void
+    {
+        $options = new SslOptions();
+        $options->setVerifyPeer(false);
+        $options->setAllowSelfSigned(true);
+
+        $context = $options->toStreamContext();
+
+        $client = new StreamSocketClient('ssl', '127.0.0.1', 12201, $context);
+        self::assertEquals($context, $client->getContext());
+    }
+}

--- a/tests/Gelf/Test/Transport/StreamSocketClientTcpTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientTcpTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Gelf\Test\Transport;
 
 use Gelf\Transport\StreamSocketClient;
-use LogicException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
@@ -23,7 +22,6 @@ class StreamSocketClientTcpTest extends TestCase
     private mixed $serverSocket;
 
     private string $host = "127.0.0.1";
-    private int $port;
 
     public function setUp(): void
     {
@@ -34,15 +32,10 @@ class StreamSocketClientTcpTest extends TestCase
             throw new RuntimeException("Failed to create test-server-socket");
         }
 
-        // get random port
-        $socketName = stream_socket_get_name(
-            $this->serverSocket,
-            remote: false
-        );
+        $socketName = stream_socket_get_name($this->serverSocket, remote: false);
         [, $port] = explode(":", $socketName);
 
         $this->socketClient = new StreamSocketClient('tcp', $host, (int)$port);
-        $this->port = (int)$port;
     }
 
     public function tearDown(): void
@@ -54,11 +47,6 @@ class StreamSocketClientTcpTest extends TestCase
         }
     }
 
-    public function testGetSocket(): void
-    {
-        self::assertIsResource($this->socketClient->getSocket());
-    }
-
     public function testWrite(): void
     {
         $testData = "Hello World!";
@@ -66,7 +54,6 @@ class StreamSocketClientTcpTest extends TestCase
 
         self::assertEquals(strlen($testData), $numBytes);
 
-        // check that message is sent to server
         $connection = stream_socket_accept($this->serverSocket);
         $readData = fread($connection, $numBytes);
 
@@ -85,26 +72,17 @@ class StreamSocketClientTcpTest extends TestCase
 
     public function testMultiWrite(): void
     {
-        // lower timeout for server-socket
         stream_set_timeout($this->serverSocket, 0, 100);
 
-        // -- first write
-
         $testData = "First thing in the morning should be to check,";
-
         $numBytes = $this->socketClient->write($testData);
         self::assertEquals(strlen($testData), $numBytes);
 
-        // open connection on server-socket
         $serverConnection = stream_socket_accept($this->serverSocket);
-
         $readData = fread($serverConnection, $numBytes);
         self::assertEquals($testData, $readData);
 
-        // -- second write
-
         $testData = "if we can write multiple times on the same socket";
-
         $numBytes = $this->socketClient->write($testData);
         self::assertEquals(strlen($testData), $numBytes);
 
@@ -117,49 +95,37 @@ class StreamSocketClientTcpTest extends TestCase
     public function testRead(): void
     {
         $testData = "Hello Reader :)";
-
         $numBytes = $this->socketClient->write($testData);
         self::assertEquals(strlen($testData), $numBytes);
 
-        // lower timeout for server-socket
         stream_set_timeout($this->serverSocket, 0, 100);
 
         $connection = stream_socket_accept($this->serverSocket);
-
-        // return input as output
         stream_copy_to_stream($connection, $connection, strlen($testData));
-
         fclose($connection);
-        $readData = $this->socketClient->read($numBytes);
 
+        $readData = $this->socketClient->read($numBytes);
         self::assertEquals($testData, $readData);
     }
 
     public function testReadContents(): void
     {
         $testData = str_repeat("0123456789", mt_rand(1, 10));
-
         $numBytes = $this->socketClient->write($testData);
         self::assertEquals(strlen($testData), $numBytes);
 
-        // lower timeout for server-socket
         stream_set_timeout($this->serverSocket, 0, 100);
 
         $connection = stream_socket_accept($this->serverSocket);
-
-        // return input as output
         stream_copy_to_stream($connection, $connection, strlen($testData));
-
         fclose($connection);
 
         $readData = $this->socketClient->read(1024);
-
         self::assertEquals($testData, $readData);
     }
 
     public function testCloseWithoutConnectionWrite(): void
     {
-        // close unopened stream
         $this->socketClient->close();
         self::assertTrue($this->socketClient->isClosed());
 
@@ -182,64 +148,5 @@ class StreamSocketClientTcpTest extends TestCase
         $this->socketClient->write("efgh");
         $client2 = stream_socket_accept($this->serverSocket);
         self::assertEquals("efgh", fread($client2, 4));
-    }
-
-    public function testStreamContext(): void
-    {
-        $testName = '127.0.0.1:12345';
-        $context = [
-            'socket' => [
-                'bindto' => $testName
-            ]
-        ];
-
-        $client = new StreamSocketClient("tcp", $this->host, $this->port, $context);
-        self::assertEquals($context, $client->getContext());
-
-        self::assertEquals($testName, stream_socket_get_name($client->getSocket(), false));
-        self::assertNotEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
-    }
-
-    public function testUpdateStreamContext(): void
-    {
-        $testName = '127.0.0.1:12345';
-        $context = array(
-            'socket' => array(
-                'bindto' => $testName
-            )
-        );
-
-        self::assertEquals(array(), $this->socketClient->getContext());
-        self::assertNotEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
-        $this->socketClient->close();
-
-        $this->socketClient->setContext($context);
-        self::assertEquals($context, $this->socketClient->getContext());
-
-        self::assertEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
-    }
-
-    public function testSetContextFailsAfterConnect(): void
-    {
-        self::expectException(LogicException::class);
-        // enforce connect
-        $this->socketClient->getSocket();
-
-        $this->socketClient->setContext(array("foo" => "bar"));
-    }
-
-    public function testSetConnectTimeoutFailsAfterConnect(): void
-    {
-        self::expectException(LogicException::class);
-        // enforce connect
-        $this->socketClient->getSocket();
-
-        $this->socketClient->setConnectTimeout(1);
-    }
-
-    public function testConnectTimeout()
-    {
-        $this->socketClient->setConnectTimeout(1);
-        self::assertEquals(1, $this->socketClient->getConnectTimeout());
     }
 }

--- a/tests/Gelf/Test/Transport/StreamSocketClientTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientTest.php
@@ -1,0 +1,122 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the php-gelf package.
+ *
+ * (c) Benjamin Zikarsky <http://benjamin-zikarsky.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Gelf\Test\Transport;
+
+use Gelf\Transport\StreamSocketClient;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class StreamSocketClientTest extends TestCase
+{
+    private StreamSocketClient $socketClient;
+    private mixed $serverSocket;
+
+    private string $host = "127.0.0.1";
+    private int $port;
+
+    public function setUp(): void
+    {
+        $host = $this->host;
+        $this->serverSocket = stream_socket_server("tcp://$host:0");
+
+        if (!$this->serverSocket) {
+            throw new RuntimeException("Failed to create test-server-socket");
+        }
+
+        $socketName = stream_socket_get_name($this->serverSocket, remote: false);
+        [, $port] = explode(":", $socketName);
+
+        $this->socketClient = new StreamSocketClient('tcp', $host, (int)$port);
+        $this->port = (int)$port;
+    }
+
+    public function tearDown(): void
+    {
+        unset($this->socketClient);
+        if ($this->serverSocket !== null) {
+            fclose($this->serverSocket);
+            $this->serverSocket = null;
+        }
+    }
+
+    public function testInvalidConstructorArguments(): void
+    {
+        self::expectException(RuntimeException::class);
+
+        $client = new StreamSocketClient("not-a-scheme", "not-a-host", -1);
+        $client->getSocket();
+    }
+
+    public function testGetSocket(): void
+    {
+        self::assertIsResource($this->socketClient->getSocket());
+    }
+
+    public function testStreamContext(): void
+    {
+        $testName = '127.0.0.1:12345';
+        $context = [
+            'socket' => [
+                'bindto' => $testName
+            ]
+        ];
+
+        $client = new StreamSocketClient("tcp", $this->host, $this->port, $context);
+        self::assertEquals($context, $client->getContext());
+
+        self::assertEquals($testName, stream_socket_get_name($client->getSocket(), false));
+        self::assertNotEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
+    }
+
+    public function testUpdateStreamContext(): void
+    {
+        $testName = '127.0.0.1:12345';
+        $context = [
+            'socket' => [
+                'bindto' => $testName
+            ]
+        ];
+
+        self::assertEquals([], $this->socketClient->getContext());
+        self::assertNotEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
+        $this->socketClient->close();
+
+        $this->socketClient->setContext($context);
+        self::assertEquals($context, $this->socketClient->getContext());
+
+        self::assertEquals($testName, stream_socket_get_name($this->socketClient->getSocket(), false));
+    }
+
+    public function testSetContextFailsAfterConnect(): void
+    {
+        self::expectException(LogicException::class);
+
+        $this->socketClient->getSocket();
+        $this->socketClient->setContext(["foo" => "bar"]);
+    }
+
+    public function testSetConnectTimeoutFailsAfterConnect(): void
+    {
+        self::expectException(LogicException::class);
+
+        $this->socketClient->getSocket();
+        $this->socketClient->setConnectTimeout(1);
+    }
+
+    public function testConnectTimeout(): void
+    {
+        $this->socketClient->setConnectTimeout(1);
+        self::assertEquals(1, $this->socketClient->getConnectTimeout());
+    }
+}

--- a/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
+++ b/tests/Gelf/Test/Transport/StreamSocketClientUdpTest.php
@@ -32,14 +32,10 @@ class StreamSocketClientUdpTest extends TestCase
         );
 
         if (!$this->serverSocket) {
-            throw new \RuntimeException("Failed to create test-server-socket");
+            throw new RuntimeException("Failed to create test-server-socket");
         }
 
-        // get random port
-        $socketName = stream_socket_get_name(
-            $this->serverSocket,
-            remote: false
-        );
+        $socketName = stream_socket_get_name($this->serverSocket, remote: false);
         [, $port] = explode(":", $socketName);
 
         $this->socketClient = new StreamSocketClient('udp', $host, (int)$port);
@@ -51,19 +47,6 @@ class StreamSocketClientUdpTest extends TestCase
         fclose($this->serverSocket);
     }
 
-    public function testInvalidConstructorArguments(): void
-    {
-        self::expectException(RuntimeException::class);
-
-        $client = new StreamSocketClient("not-a-scheme", "not-a-host", -1);
-        $client->getSocket();
-    }
-
-    public function testGetSocket(): void
-    {
-        self::assertIsResource($this->socketClient->getSocket());
-    }
-
     public function testWrite(): void
     {
         $testData = "Hello World!";
@@ -71,7 +54,6 @@ class StreamSocketClientUdpTest extends TestCase
 
         self::assertEquals(strlen($testData), $numBytes);
 
-        // check that message is sent to server
         $readData = fread($this->serverSocket, $numBytes);
 
         self::assertEquals($testData, $readData);


### PR DESCRIPTION
Split the two existing test files (Tcp and Udp) into four focused test cases as described in issue #112:

- StreamSocketClientTest: general protocol-agnostic tests extracted from the TCP file (context management, timeout, socket lifecycle, invalid constructor arguments)
- StreamSocketClientTcpTest: TCP-specific data transfer tests only (write, bad write, multi-write, read, close behaviors)
- StreamSocketClientUdpTest: trimmed to UDP-specific write test only, removing duplicates now covered by the general test case
- StreamSocketClientSslTest: new test case covering SSL failure path (connecting with ssl:// to a plain TCP server) and SSL context preservation through the constructor

Fix three pre-existing Psalm errors surfaced during this work:

- Logger.php: add @param docblock for $message (string|\Stringable) without touching the PHP signature, which must stay untyped for psr/log ^1 compatibility (see #151)
- Message.php: add explicit mixed type and @psalm-suppress on the empty() call inside the array_filter closure to preserve the existing behavior
- HttpTransport.php: replace truthy check on null|string with strict null and empty-string comparisons in fromUrl()

Closes #112